### PR TITLE
Minor /bin/sh fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "build": "node-gyp build --jobs=max",
     "install": "test -f build/Release/medooze-media-server.node || (node-gyp configure && node-gyp rebuild --jobs=max)",
     "docs": "documentation build lib/MediaServer.js lib/*.js node_modules/semantic-sdp/lib/*.js --shallow -o docs -f html",
-    "package": "tar cvzf build/medooze-media-server.tgz  `([ \"$(uname)\" == 'Darwin' ] && echo \"-s |^|medooze-media-server/|\") || echo \" --transform=flags=r;s|^|medooze-media-server/|\"` external/* media-server/src/* media-server/include/* lib/* package.json index.js  binding.gyp  README.md src",
-    "dist": "node-gyp configure && node-gyp build --jobs=max && mkdir -p dist && tar cvzf dist/medooze-media-server-`node -e 'console.log(require(\"./package.json\").version)'`.tgz `([ \"$(uname)\" == 'Darwin' ] && echo \"-s |^|medooze-media-server/|\") || echo \" --transform=flags=r;s|^|medooze-media-server/|\"` package.json index.js   README.md lib/* build/Release/medooze-media-server.node",
+    "package": "tar cvzf build/medooze-media-server.tgz  `([ \"$(uname)\" = 'Darwin' ] && echo \"-s |^|medooze-media-server/|\") || echo \" --transform=flags=r;s|^|medooze-media-server/|\"` external/* media-server/src/* media-server/include/* lib/* package.json index.js  binding.gyp  README.md src",
+    "dist": "node-gyp configure && node-gyp build --jobs=max && mkdir -p dist && tar cvzf dist/medooze-media-server-`node -e 'console.log(require(\"./package.json\").version)'`.tgz `([ \"$(uname)\" = 'Darwin' ] && echo \"-s |^|medooze-media-server/|\") || echo \" --transform=flags=r;s|^|medooze-media-server/|\"` package.json index.js   README.md lib/* build/Release/medooze-media-server.node",
     "test": "tap tests/*.js --cov"
   },
   "repository": {


### PR DESCRIPTION
You'll see this error for both package and dist scripts

> sh: 1: [: Linux: unexpected operator

For any shell commands run inside package.json scripts apparently uses specifically /bin/sh (not bash), and both [ and test require to use = for equivalence, not ==.