### PR TITLE
Fix outgoingStream createTrack media type

### DIFF
--- a/lib/OutgoingStream.js
+++ b/lib/OutgoingStream.js
@@ -308,7 +308,7 @@ class OutgoingStream
 		let trackId;
 		
 		//Get media type
-		const media = params.constructor.name === "TrackInfo" ? params.getMedia() : params && params.id ? params.id : params;
+		const media = params.constructor.name === "TrackInfo" ? params.getMedia() : params && params.media ? params.media : "audio";
 		
 		//Is it audio or video
 		const type  = media==="audio" ? 0 : 1;


### PR DESCRIPTION
outputStream::createTrack() track id assigned to media type. Please confirm expected behavior
```javascript
const outputTrack = outputStream.createTrack({
   id: inputTrack.getId(),
   media: inputTrack.getMedia()
   });
```