### PR TITLE
SDPManagerUnified: fix createIncomingStream

### DIFF
--- a/lib/SDPManagerUnified.js
+++ b/lib/SDPManagerUnified.js
@@ -283,13 +283,11 @@ class SDPManagerUnified extends SDPManager
 					if (!stream) {
 						//Create new one
 						stream = this.transport.createIncomingStream(streamInfo);
-						if (!track && trackInfo) {
-							track = stream.getTrack(trackInfo.getId());
-							//If we don't have a track already
-							if (!track)
-								//Create new one on the stream
-								stream.createTrack(trackInfo);
-						}
+					}
+					//If we don't have a track already
+					else if (!track && trackInfo) {
+						//Create new one on the stream
+						stream.createTrack(trackInfo);
 					}
 					//Store track and stream info
 					transceiver.remote.streamId	= stream.getId();

--- a/lib/SDPManagerUnified.js
+++ b/lib/SDPManagerUnified.js
@@ -280,13 +280,17 @@ class SDPManagerUnified extends SDPManager
 						//Stop it
 						transceiver.remote.track.stop();
 					//If we don't have stream
-					if (!stream)
+					if (!stream) {
 						//Create new one
 						stream = this.transport.createIncomingStream(streamInfo);
-					//If we don't have a track already
-					if (!track && trackInfo)
-						//Create new one on the stream
-						stream.createTrack(trackInfo);
+						if (!track && trackInfo) {
+							track = stream.getTrack(trackInfo.getId());
+							//If we don't have a track already
+							if (!track)
+								//Create new one on the stream
+								stream.createTrack(trackInfo);
+						}
+					}
 					//Store track and stream info
 					transceiver.remote.streamId	= stream.getId();
 					transceiver.remote.track	= track;


### PR DESCRIPTION
Please check.
```javascript
this.transport.createIncomingStream(streamInfo);
```
already creates track here.
`[ERR]-AddIncomingSourceGroup media ssrc already assigned` will be thrown if we create new existing track
