### PR TITLE
SDPManagerUnified. Fix stopping of the track in Firefox

### DIFF
--- a/lib/SDPManagerUnified.js
+++ b/lib/SDPManagerUnified.js
@@ -323,10 +323,13 @@ class SDPManagerUnified extends SDPManager
 			let stream = streamInfo ? this.transport.getIncomingStream(streamInfo.getId()) : null;
 			//Get track
 			let track = stream && trackInfo ? stream.getTrack(trackInfo.getId()) : null;
+			//Define origin track which was attached to transceiver previously
+			let originTransceiverTrack = null;
+
 			//Get transceiver
 			let transceiver = this.transceivers[i];
 			//If there is a transceiver
-			if (!transceiver)
+			if (!transceiver) {
 				//Crete new one
 				transceiver = this.transceivers[i] = {
 					mid	: mid,
@@ -337,9 +340,13 @@ class SDPManagerUnified extends SDPManager
 						info		:  mediaInfo.answer(this.capabilities),
 					}
 				};
-			else
+			} else {
+				if (transceiver.remote){
+					originTransceiverTrack = transceiver.remote.track;
+				}
 				//Update media info
 				transceiver.remote = mediaInfo;
+			}
 			//Next transceiver
 			i++;
 			//Check new direction for remote stuff
@@ -373,6 +380,10 @@ class SDPManagerUnified extends SDPManager
 					if (track)
 						//Stop it
 						track.stop();
+					else if (originTransceiverTrack)
+						// Some clients (e.g. Firefox) doesn't send ids of stopped tracks or streams in msid for inactive transceivers in SDP.
+						// If remote track not found, try to get originally attached remote track from this tranceiver and stop it.
+						originTransceiverTrack.stop();
 					//Delete it from transceiver
 					delete (transceiver.remote.track);
 					break;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medooze-media-server",
-  "version": "0.79.6",
+  "version": "0.80.0",
   "description": "WebRTC Media Server by Medooze",
   "main": "index.js",
   "types": "./medooze-media-server.d.ts",


### PR DESCRIPTION
**Problem**: Firefox doesn't send track ids of stopped tracks in SDP. A track which was stopped in Firefox isn't being stopped by SDPManagerUnified during renegotiation.

**How to reproduce**:
1. Start a video conference with participant A (Chrome) and B (Firefox) with SDPManagerUnified.
2. Share screen by participant B and make sure participant A sees it.
3. Stop screen sharing.
4. Participant A still see the empty screen-sharing track, no renegotiation has been made for participant A.

Offer for step 2 (screen-sharing id `c9183dc8-91ef-9e41-b790-401763274e3b`)
```
v=0
o=mozilla...THIS_IS_SDPARTA-72.0.1 6718080254647937646 2 IN IP4 0.0.0.0
s=-
t=0 0
a=fingerprint:sha-256 0D:D9:E9:21:31:FD:84:18:B6:36:AC:7A:90:54:68:35:BA:47:2B:8F:95:76:67:22:52:2C:07:45:C2:37:2C:23
a=group:BUNDLE 0 1 2 3
a=ice-options:trickle
a=msid-semantic:WMS *
m=audio 52264 UDP/TLS/RTP/SAVPF 109 9 0 8 101
c=IN IP4 178.62.245.74
a=candidate:0 1 UDP 2122252543 192.168.1.3 50181 typ host
a=candidate:4 1 TCP 2105524479 192.168.1.3 9 typ host tcptype active
a=candidate:1 1 UDP 1686052863 176.105.213.249 55119 typ srflx raddr 192.168.1.3 rport 50181
a=candidate:3 1 UDP 92217087 178.62.245.74 52264 typ relay raddr 178.62.245.74 rport 52264
a=candidate:5 1 UDP 8331263 178.62.245.74 65176 typ relay raddr 178.62.245.74 rport 65176
a=sendrecv
a=end-of-candidates
a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
a=extmap:2/recvonly urn:ietf:params:rtp-hdrext:csrc-audio-level
a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
a=fmtp:109 maxplaybackrate=48000;stereo=1;useinbandfec=1
a=fmtp:101 0-15
a=ice-pwd:877cf239c1c1c5fa02efe02746c4f5e8
a=ice-ufrag:bebbd69c
a=mid:0
a=msid:{d2d9fcd9-bbcb-af41-ad99-8332230e8ecb} {39612ac6-7607-fc40-97f0-96dca69c436c}
a=rtcp-mux
a=rtpmap:109 opus/48000/2
a=rtpmap:9 G722/8000/1
a=rtpmap:0 PCMU/8000
a=rtpmap:8 PCMA/8000
a=rtpmap:101 telephone-event/8000/1
a=setup:actpass
a=ssrc:501563061 cname:{baf530d5-f878-384d-a075-d6cee8d59f99}
m=video 0 UDP/TLS/RTP/SAVPF 120 121 126 97
c=IN IP4 0.0.0.0
a=bundle-only
a=sendrecv
a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:4 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
a=extmap:5 urn:ietf:params:rtp-hdrext:toffset
a=extmap:6/recvonly http://www.webrtc.org/experiments/rtp-hdrext/playout-delay
a=fmtp:126 profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1
a=fmtp:97 profile-level-id=42e01f;level-asymmetry-allowed=1
a=fmtp:120 max-fs=12288;max-fr=60
a=fmtp:121 max-fs=12288;max-fr=60
a=ice-pwd:877cf239c1c1c5fa02efe02746c4f5e8
a=ice-ufrag:bebbd69c
a=mid:1
a=msid:{d2d9fcd9-bbcb-af41-ad99-8332230e8ecb} {892f1796-51a7-3247-95e4-4bab29cd77d7}
a=rtcp-fb:120 nack
a=rtcp-fb:120 nack pli
a=rtcp-fb:120 ccm fir
a=rtcp-fb:120 goog-remb
a=rtcp-fb:121 nack
a=rtcp-fb:121 nack pli
a=rtcp-fb:121 ccm fir
a=rtcp-fb:121 goog-remb
a=rtcp-fb:126 nack
a=rtcp-fb:126 nack pli
a=rtcp-fb:126 ccm fir
a=rtcp-fb:126 goog-remb
a=rtcp-fb:97 nack
a=rtcp-fb:97 nack pli
a=rtcp-fb:97 ccm fir
a=rtcp-fb:97 goog-remb
a=rtcp-mux
a=rtpmap:120 VP8/90000
a=rtpmap:121 VP9/90000
a=rtpmap:126 H264/90000
a=rtpmap:97 H264/90000
a=setup:actpass
a=ssrc:4288781018 cname:{baf530d5-f878-384d-a075-d6cee8d59f99}
m=audio 0 UDP/TLS/RTP/SAVPF 109 9 0 8 101
c=IN IP4 0.0.0.0
a=bundle-only
a=recvonly
a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
a=extmap:2/recvonly urn:ietf:params:rtp-hdrext:csrc-audio-level
a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
a=fmtp:109 maxplaybackrate=48000;stereo=1;useinbandfec=1
a=fmtp:101 0-15
a=ice-pwd:877cf239c1c1c5fa02efe02746c4f5e8
a=ice-ufrag:bebbd69c
a=mid:2
a=rtcp-mux
a=rtpmap:109 opus/48000/2
a=rtpmap:9 G722/8000/1
a=rtpmap:0 PCMU/8000
a=rtpmap:8 PCMA/8000
a=rtpmap:101 telephone-event/8000/1
a=setup:actpass
a=ssrc:3592518956 cname:{baf530d5-f878-384d-a075-d6cee8d59f99}
m=video 0 UDP/TLS/RTP/SAVPF 120 121 126 97
c=IN IP4 0.0.0.0
a=bundle-only
a=sendrecv
a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:4 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
a=extmap:5 urn:ietf:params:rtp-hdrext:toffset
a=extmap:6/recvonly http://www.webrtc.org/experiments/rtp-hdrext/playout-delay
a=fmtp:126 profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1
a=fmtp:97 profile-level-id=42e01f;level-asymmetry-allowed=1
a=fmtp:120 max-fs=12288;max-fr=60
a=fmtp:121 max-fs=12288;max-fr=60
a=ice-pwd:877cf239c1c1c5fa02efe02746c4f5e8
a=ice-ufrag:bebbd69c
a=mid:3
a=msid:{c9183dc8-91ef-9e41-b790-401763274e3b} {b9551048-c421-9e4e-9f00-d209c6dee056}
a=rtcp-fb:120 nack
a=rtcp-fb:120 nack pli
a=rtcp-fb:120 ccm fir
a=rtcp-fb:120 goog-remb
a=rtcp-fb:121 nack
a=rtcp-fb:121 nack pli
a=rtcp-fb:121 ccm fir
a=rtcp-fb:121 goog-remb
a=rtcp-fb:126 nack
a=rtcp-fb:126 nack pli
a=rtcp-fb:126 ccm fir
a=rtcp-fb:126 goog-remb
a=rtcp-fb:97 nack
a=rtcp-fb:97 nack pli
a=rtcp-fb:97 ccm fir
a=rtcp-fb:97 goog-remb
a=rtcp-mux
a=rtpmap:120 VP8/90000
a=rtpmap:121 VP9/90000
a=rtpmap:126 H264/90000
a=rtpmap:97 H264/90000
a=setup:actpass
a=ssrc:2262268235 cname:{baf530d5-f878-384d-a075-d6cee8d59f99}
```
Offer for step 3. As you can see the offer doesn't contain stream id `c9183dc8-91ef-9e41-b790-401763274e3b` and mid=3 doesn't have msid section
```
v=0
o=mozilla...THIS_IS_SDPARTA-72.0.1 6718080254647937646 3 IN IP4 0.0.0.0
s=-
t=0 0
a=fingerprint:sha-256 0D:D9:E9:21:31:FD:84:18:B6:36:AC:7A:90:54:68:35:BA:47:2B:8F:95:76:67:22:52:2C:07:45:C2:37:2C:23
a=group:BUNDLE 0 1 2 3
a=ice-options:trickle
a=msid-semantic:WMS *
m=audio 52264 UDP/TLS/RTP/SAVPF 109 9 0 8 101
c=IN IP4 178.62.245.74
a=candidate:0 1 UDP 2122252543 192.168.1.3 50181 typ host
a=candidate:4 1 TCP 2105524479 192.168.1.3 9 typ host tcptype active
a=candidate:1 1 UDP 1686052863 176.105.213.249 55119 typ srflx raddr 192.168.1.3 rport 50181
a=candidate:3 1 UDP 92217087 178.62.245.74 52264 typ relay raddr 178.62.245.74 rport 52264
a=candidate:5 1 UDP 8331263 178.62.245.74 65176 typ relay raddr 178.62.245.74 rport 65176
a=sendrecv
a=end-of-candidates
a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
a=extmap:2/recvonly urn:ietf:params:rtp-hdrext:csrc-audio-level
a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
a=fmtp:109 maxplaybackrate=48000;stereo=1;useinbandfec=1
a=fmtp:101 0-15
a=ice-pwd:877cf239c1c1c5fa02efe02746c4f5e8
a=ice-ufrag:bebbd69c
a=mid:0
a=msid:{d2d9fcd9-bbcb-af41-ad99-8332230e8ecb} {39612ac6-7607-fc40-97f0-96dca69c436c}
a=rtcp-mux
a=rtpmap:109 opus/48000/2
a=rtpmap:9 G722/8000/1
a=rtpmap:0 PCMU/8000
a=rtpmap:8 PCMA/8000
a=rtpmap:101 telephone-event/8000/1
a=setup:actpass
a=ssrc:501563061 cname:{baf530d5-f878-384d-a075-d6cee8d59f99}
m=video 0 UDP/TLS/RTP/SAVPF 120 121 126 97
c=IN IP4 0.0.0.0
a=bundle-only
a=sendrecv
a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:4 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
a=extmap:5 urn:ietf:params:rtp-hdrext:toffset
a=extmap:6/recvonly http://www.webrtc.org/experiments/rtp-hdrext/playout-delay
a=fmtp:126 profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1
a=fmtp:97 profile-level-id=42e01f;level-asymmetry-allowed=1
a=fmtp:120 max-fs=12288;max-fr=60
a=fmtp:121 max-fs=12288;max-fr=60
a=ice-pwd:877cf239c1c1c5fa02efe02746c4f5e8
a=ice-ufrag:bebbd69c
a=mid:1
a=msid:{d2d9fcd9-bbcb-af41-ad99-8332230e8ecb} {892f1796-51a7-3247-95e4-4bab29cd77d7}
a=rtcp-fb:120 nack
a=rtcp-fb:120 nack pli
a=rtcp-fb:120 ccm fir
a=rtcp-fb:120 goog-remb
a=rtcp-fb:121 nack
a=rtcp-fb:121 nack pli
a=rtcp-fb:121 ccm fir
a=rtcp-fb:121 goog-remb
a=rtcp-fb:126 nack
a=rtcp-fb:126 nack pli
a=rtcp-fb:126 ccm fir
a=rtcp-fb:126 goog-remb
a=rtcp-fb:97 nack
a=rtcp-fb:97 nack pli
a=rtcp-fb:97 ccm fir
a=rtcp-fb:97 goog-remb
a=rtcp-mux
a=rtpmap:120 VP8/90000
a=rtpmap:121 VP9/90000
a=rtpmap:126 H264/90000
a=rtpmap:97 H264/90000
a=setup:actpass
a=ssrc:4288781018 cname:{baf530d5-f878-384d-a075-d6cee8d59f99}
m=audio 0 UDP/TLS/RTP/SAVPF 109 9 0 8 101
c=IN IP4 0.0.0.0
a=bundle-only
a=recvonly
a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
a=extmap:2/recvonly urn:ietf:params:rtp-hdrext:csrc-audio-level
a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
a=fmtp:109 maxplaybackrate=48000;stereo=1;useinbandfec=1
a=fmtp:101 0-15
a=ice-pwd:877cf239c1c1c5fa02efe02746c4f5e8
a=ice-ufrag:bebbd69c
a=mid:2
a=rtcp-mux
a=rtpmap:109 opus/48000/2
a=rtpmap:9 G722/8000/1
a=rtpmap:0 PCMU/8000
a=rtpmap:8 PCMA/8000
a=rtpmap:101 telephone-event/8000/1
a=setup:actpass
a=ssrc:3592518956 cname:{baf530d5-f878-384d-a075-d6cee8d59f99}
m=video 0 UDP/TLS/RTP/SAVPF 120 121 126 97
c=IN IP4 0.0.0.0
a=bundle-only
a=recvonly
a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:4 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
a=extmap:5 urn:ietf:params:rtp-hdrext:toffset
a=extmap:6/recvonly http://www.webrtc.org/experiments/rtp-hdrext/playout-delay
a=fmtp:126 profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1
a=fmtp:97 profile-level-id=42e01f;level-asymmetry-allowed=1
a=fmtp:120 max-fs=12288;max-fr=60
a=fmtp:121 max-fs=12288;max-fr=60
a=ice-pwd:877cf239c1c1c5fa02efe02746c4f5e8
a=ice-ufrag:bebbd69c
a=mid:3
a=rtcp-fb:120 nack
a=rtcp-fb:120 nack pli
a=rtcp-fb:120 ccm fir
a=rtcp-fb:120 goog-remb
a=rtcp-fb:121 nack
a=rtcp-fb:121 nack pli
a=rtcp-fb:121 ccm fir
a=rtcp-fb:121 goog-remb
a=rtcp-fb:126 nack
a=rtcp-fb:126 nack pli
a=rtcp-fb:126 ccm fir
a=rtcp-fb:126 goog-remb
a=rtcp-fb:97 nack
a=rtcp-fb:97 nack pli
a=rtcp-fb:97 ccm fir
a=rtcp-fb:97 goog-remb
a=rtcp-mux
a=rtpmap:120 VP8/90000
a=rtpmap:121 VP9/90000
a=rtpmap:126 H264/90000
a=rtpmap:97 H264/90000
a=setup:actpass
a=ssrc:2262268235 cname:{baf530d5-f878-384d-a075-d6cee8d59f99}
```
