### PR TITLE
Refresher delete track error

### DIFF
--- a/lib/Refresher.js
+++ b/lib/Refresher.js
@@ -39,8 +39,8 @@ class Refresher
 		
 		//Listener for stop track events
 		this.ontrackstopped = (track) => {
-			//Remove from set
-			this.tracks.delete(track);
+			//Remove from set, but check that it exists as event might be fired after stop()
+			this.tracks && this.tracks.delete(track);
 		};
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medooze-media-server",
-  "version": "0.79.6",
+  "version": "0.80.0",
   "description": "WebRTC Media Server by Medooze",
   "main": "index.js",
   "types": "./medooze-media-server.d.ts",


### PR DESCRIPTION
Sometimes Refresher.js cause an error during renegotiation:
```
TypeError: Cannot read property 'delete' of null
    at EventEmitter.Refresher.ontrackstopped (/usr/src/node_modules/medooze-media-server/lib/Refresher.js:43:16)
    at Object.onceWrapper (events.js:277:13)
    at EventEmitter.emit (events.js:194:15)
    at IncomingStreamTrack.stop (/usr/src/node_modules/medooze-media-server/lib/IncomingStreamTrack.js:486:16)
    at IncomingStream.stop (/usr/src/node_modules/medooze-media-server/lib/IncomingStream.js:417:10)
    at EventEmitter.track.on (/usr/src/components/Participant.js:141:24)
    at EventEmitter.emit (events.js:194:15)
    at IncomingStreamTrack.stop (/usr/src/node_modules/medooze-media-server/lib/IncomingStreamTrack.js:486:16)
    at SDPManagerUnified.processRemoteDescription (/usr/src/node_modules/medooze-media-server/lib/SDPManagerUnified.js:379:13)
```

 It happens sometimes if a stream stops after Refresher.stop() method is triggered