### PR TITLE
Move tap test framework to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "lfsr": "0.0.3",
     "nan": "^2.11.1",
     "semantic-sdp": "^3",
-    "tap": "^14",
     "uuid": "^3.3.2"
+  },
+  "devDependencies": {
+    "tap": "^14"
   }
 }


### PR DESCRIPTION
This reduces the number of packages installed for a simple project considerably, from ~250 to ~8 and reduces the `node_modules` size by about 100MB.