### PR TITLE
raw frame sending PoC

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -77,6 +77,7 @@
 							"media-server/src/ActiveSpeakerMultiplexer.cpp",
 							"media-server/src/EventLoop.cpp",
 							"media-server/src/RawTxHelper.cpp",
+							"media-server/src/PacketHeader.cpp",
 							"media-server/src/RTPBundleTransport.cpp",
 							"media-server/src/DTLSICETransport.cpp",
 							"media-server/src/VideoLayerSelector.cpp",

--- a/binding.gyp
+++ b/binding.gyp
@@ -77,6 +77,7 @@
 							"media-server/src/ActiveSpeakerMultiplexer.cpp",
 							"media-server/src/EventLoop.cpp",
 							"media-server/src/PacketHeader.cpp",
+							"media-server/src/MacAddress.cpp",
 							"media-server/src/RTPBundleTransport.cpp",
 							"media-server/src/DTLSICETransport.cpp",
 							"media-server/src/VideoLayerSelector.cpp",

--- a/binding.gyp
+++ b/binding.gyp
@@ -76,6 +76,7 @@
 							"media-server/src/ActiveSpeakerDetector.cpp",
 							"media-server/src/ActiveSpeakerMultiplexer.cpp",
 							"media-server/src/EventLoop.cpp",
+							"media-server/src/RawTxHelper.cpp",
 							"media-server/src/RTPBundleTransport.cpp",
 							"media-server/src/DTLSICETransport.cpp",
 							"media-server/src/VideoLayerSelector.cpp",

--- a/binding.gyp
+++ b/binding.gyp
@@ -76,7 +76,6 @@
 							"media-server/src/ActiveSpeakerDetector.cpp",
 							"media-server/src/ActiveSpeakerMultiplexer.cpp",
 							"media-server/src/EventLoop.cpp",
-							"media-server/src/RawTxHelper.cpp",
 							"media-server/src/PacketHeader.cpp",
 							"media-server/src/RTPBundleTransport.cpp",
 							"media-server/src/DTLSICETransport.cpp",

--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -84,15 +84,19 @@ class Endpoint
 	async setRawTx(options)
 	{
 		// if false was passed, disable raw TX sending
-		if (options === false)
-			return this.bundle.ClearRawTx();
+		if (options === false) {
+			this.bundle.ClearRawTx();
+			delete this.bundle.rawTxInterface;
+			return;
+		}
 		// gather necessary information and pass it to the bundle
 		const config = await NetworkUtils.getInterfaceRawConfig(options.interfaceName);
 		const port = this.getLocalPort();
-		return this.bundle.SetRawTx(
+		this.bundle.SetRawTx(
 			config.index, options.sndBuf || 0, !!options.skipQdisc,
 			config.addr[0], config.addr[1], config.lladdr, config.gatewayAddr, config.gatewayLladdr, port,
 		);
+		this.bundle.rawTxInterface = config.index;
 	}
 
 	/**

--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -65,7 +65,7 @@ class Endpoint
 			mirrors : new Set()
 		};
 	}
-
+	
 	/**
 	 * Set cpu affinity for udp send/recv thread.
 	 * @param {Number}  cpu - CPU core or -1 to reset affinity.

--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -94,7 +94,7 @@ class Endpoint
 		const port = this.getLocalPort();
 		this.bundle.SetRawTx(
 			config.index, options.sndBuf || 0, !!options.skipQdisc,
-			config.lladdr, ...config.fallbackData, port,
+			config.lladdr, ...config.defaultRoute, port,
 		);
 		this.bundle.rawTxInterface = config.index;
 	}

--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -1,3 +1,4 @@
+const NetworkUtils			= require("./NetworkUtils");
 const Native				= require("./Native");
 const EventEmitter			= require('events').EventEmitter;
 const Transport				= require("./Transport");
@@ -64,7 +65,7 @@ class Endpoint
 			mirrors : new Set()
 		};
 	}
-	
+
 	/**
 	 * Set cpu affinity for udp send/recv thread.
 	 * @param {Number}  cpu - CPU core or -1 to reset affinity.
@@ -76,6 +77,23 @@ class Endpoint
 		return this.bundle.SetAffinity(parseInt(cpu));
 	}
 
+
+	/**
+	 * [EXPERIMENTAL] See TypeScript typings for usage.
+	 */
+	async setRawTx(options)
+	{
+		// if false was passed, disable raw TX sending
+		if (options === false)
+			return this.bundle.ClearRawTx();
+		// gather necessary information and pass it to the bundle
+		const config = await NetworkUtils.getInterfaceRawConfig(options.interface);
+		const port = this.getLocalPort();
+		return this.bundle.SetRawTx(
+			config.index, options.sndBuf || 0, !!options.skipQdisc,
+			config.addr[0], config.addr[1], config.lladdr, config.gatewayAddr, config.gatewayLladdr, port,
+		);
+	}
 
 	/**
 	 * Set name for udp send/recv thread.

--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -87,7 +87,7 @@ class Endpoint
 		if (options === false)
 			return this.bundle.ClearRawTx();
 		// gather necessary information and pass it to the bundle
-		const config = await NetworkUtils.getInterfaceRawConfig(options.interface);
+		const config = await NetworkUtils.getInterfaceRawConfig(options.interfaceName);
 		const port = this.getLocalPort();
 		return this.bundle.SetRawTx(
 			config.index, options.sndBuf || 0, !!options.skipQdisc,

--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -94,7 +94,7 @@ class Endpoint
 		const port = this.getLocalPort();
 		this.bundle.SetRawTx(
 			config.index, options.sndBuf || 0, !!options.skipQdisc,
-			config.addr[0], config.addr[1], config.lladdr, config.gatewayAddr, config.gatewayLladdr, port,
+			config.lladdr, ...config.fallbackData, port,
 		);
 		this.bundle.rawTxInterface = config.index;
 	}

--- a/lib/NetworkUtils.js
+++ b/lib/NetworkUtils.js
@@ -1,0 +1,141 @@
+//@ts-check
+const util = require('util');
+const delay = util.promisify(setTimeout);
+
+
+// Utilities to manipulate IPv4 addresses
+
+/** parse a CIDR into a normalized [address as u32be, prefix length] tuple */
+function parseCIDR(cidr)
+{
+	cidr = /^((?:\d+\.){3}\d+)\/(\d+)$/.exec(cidr);
+	if (!cidr)
+		throw Error(`invalid CIDR: ${cidr}`)
+	const [addr, prefix] = [].slice.call(cidr, 1);
+	const verifyRange = (x, max) => {
+		x = parseInt(x);
+		if (x > max)
+			throw Error(`${x} exceeds ${max}`);
+		return x;
+	}
+	const rawAddr = Buffer.from(addr.split('.').map(x => verifyRange(x, 255)));
+	return [rawAddr.readUInt32BE(), verifyRange(prefix, 32)];
+}
+
+const cidrMask = (n) => (~0) << (32 - n);
+const isInsidePrefix = (prefix, addr) => prefix[1] <= addr[1] && !((prefix[0] ^ addr[0]) & cidrMask(prefix[1]));
+const isReservedAddress = (addr) => reservedRanges.some(range => isInsidePrefix(range, addr));
+
+const reservedRanges = [
+	'0.0.0.0/8',
+	'10.0.0.0/8',
+	'100.64.0.0/10',
+	'127.0.0.0/8',
+	'169.254.0.0/16',
+	'172.16.0.0/12',
+	'192.0.0.0/24',
+	'192.0.2.0/24',
+	'192.88.99.0/24',
+	'192.168.0.0/16',
+	'198.18.0.0/15',
+	'198.51.100.0/24',
+	'203.0.113.0/24',
+	'224.0.0.0/4',
+	'233.252.0.0/24',
+	'240.0.0.0/4',
+	'255.255.255.255/32',
+].map(parseCIDR);
+
+
+// Utilities to query network configuration through Netlink
+// (since this is only available on Linux, we must make sure
+// to handle module not existing on other platforms)
+
+const netlink = (() => {
+	try {
+		return require('netlink');
+	} catch (e) {}
+})();
+
+// use a single, shared socket for queries
+/** @type {import('netlink').RtNetlinkSocket} */
+let rtNetlink;
+
+function ensureSharedSocket()
+{
+	if (rtNetlink)
+		return;
+	if (!netlink)
+		throw Error('netlink unavailable or failed to import');
+	rtNetlink = netlink.createRtNetlink();
+}
+
+// cache responses for a while, to avoid collapsing socket
+/** @type {Map<string, ReturnType<typeof realGetInterfaceRawConfig>>} */
+const rawConfigCache = new Map()
+
+function getInterfaceRawConfig(name)
+{
+	let promise = rawConfigCache.get(name);
+	if (!promise) {
+		promise = realGetInterfaceRawConfig(name);
+		rawConfigCache.set(name, promise);
+		promise.then(() => delay(200), () => {}).then(() => rawConfigCache.delete(name));
+	}
+	return promise;
+}
+
+async function realGetInterfaceRawConfig(name)
+{
+	ensureSharedSocket();
+
+	// fetch link
+	const [ link ] = await rtNetlink.getLink({}, { ifname: name })
+		.catch(error => { throw Error(`failed to find interface ${name}: ${error}`) });
+	const { data: { index, type }, attrs: { address: lladdr } } = link;
+	if (type !== 'ETHER')
+		throw Error('not an Ethernet interface');
+	if (!lladdr)
+		throw Error('no physical address found on interface');
+
+	// fetch IPv4 addresses
+	let addrs = (await rtNetlink.getAddresses())
+		.filter(addr => addr.data.family === 2 && addr.data.index === index)
+		.map(addr => [ addr.attrs.address.readUInt32BE(), addr.data.prefixlen ]);
+	if (addrs.length !== 1) {
+		// try to discard reserved addresses and see if there's just 1 address left
+		addrs = addrs.filter(x => !isReservedAddress(x));
+	}
+	if (addrs.length !== 1)
+		throw Error('multiple IPv4 addresses found');
+	const [ addr ] = addrs;
+
+	// fetch IPv4 routes
+	const [gRoute, lRoute, ...extraRoutes] = (await rtNetlink.getRoutes())
+		.filter(route => route.data.family === 2 && route.attrs.oif === index && route.data.type === 'UNICAST')
+		.sort((a, b) => Number(a.data.dstLen !== 0)); // guarantee gateway goes first
+	const addrPrefix = (addr[0] & cidrMask(addr[1])) >>> 0;
+	if (!(
+		// some checks disabled for now since they don't play well since they're not flexible enough
+		//extraRoutes.length === 0 &&
+		gRoute.data.dstLen === 0 && gRoute.attrs.gateway &&
+		true //lRoute.attrs.dst.readUint32BE() === addrPrefix && lRoute.data.dstLen === addr[1]
+	))
+		throw Error('unexpected route configuration');
+	const gatewayAddr = gRoute.attrs.gateway.readUint32BE();
+
+	// fetch ARP entries (FIXME: be a bit more robust, probe if not found)
+	const neighbors = new Map((await rtNetlink.getNeighbors())
+		.filter(neigh => neigh.data.family === 2 && neigh.data.ifindex === index && neigh.data.state.reachable)
+		.map(neigh => [ neigh.attrs.dst.readUint32BE(), neigh.attrs.lladdr ]));
+	const gatewayLladdr = neighbors.get(gatewayAddr);
+	if (!gatewayLladdr)
+		throw Error('gateway ARP entry not found');
+
+	return { index, addr, lladdr, gatewayAddr, gatewayLladdr };
+}
+
+
+module.exports = {
+	getInterfaceRawConfig : getInterfaceRawConfig,
+};

--- a/lib/NetworkUtils.js
+++ b/lib/NetworkUtils.js
@@ -124,11 +124,11 @@ const getInterfaceRawConfig = (name, rtNetlink) => withSocket(async rtNetlink =>
 	const routes = (await rtNetlink.getRoutes())
 		.filter(route => route.data.family === 2 && route.attrs.oif === index && route.data.type === 'UNICAST') // filter ourselves, kernel seems to be buggy
 		.filter(route => route.data.dstLen === 0 && route.attrs.gateway);
-	const fallbackData = routes.length ? 
+	const defaultRoute = routes.length ? 
 		(await collectRoutingInfoWithRoute(rtNetlink, index, routes[0], routes[0].attrs.gateway.readUInt32BE())) :
 		[ 0, '00:00:00:00:00:00' ]; // silently give an invalid value
 
-	return { index, lladdr: formatMac(lladdr), fallbackData };
+	return { index, lladdr: formatMac(lladdr), defaultRoute };
 });
 
 const IPPROTO_UDP = 17

--- a/lib/NetworkUtils.js
+++ b/lib/NetworkUtils.js
@@ -11,7 +11,7 @@ function parseCIDR(cidr)
 	cidr = /^((?:\d+\.){3}\d+)\/(\d+)$/.exec(cidr);
 	if (!cidr)
 		throw Error(`invalid CIDR: ${cidr}`)
-	const [addr, prefix] = [].slice.call(cidr, 1);
+	const [addr, prefix] = cidr.slice(1);
 	const verifyRange = (x, max) => {
 		x = parseInt(x);
 		if (x > max)
@@ -111,15 +111,14 @@ async function realGetInterfaceRawConfig(name)
 	const [ addr ] = addrs;
 
 	// fetch IPv4 routes
-	const [gRoute, lRoute, ...extraRoutes] = (await rtNetlink.getRoutes())
+	const [gRoute, ...extraRoutes] = (await rtNetlink.getRoutes())
 		.filter(route => route.data.family === 2 && route.attrs.oif === index && route.data.type === 'UNICAST')
 		.sort((a, b) => Number(a.data.dstLen !== 0)); // guarantee gateway goes first
 	const addrPrefix = (addr[0] & cidrMask(addr[1])) >>> 0;
 	if (!(
-		// some checks disabled for now since they don't play well since they're not flexible enough
-		//extraRoutes.length === 0 &&
+		// some checks disabled for now since they don't play well, not flexible enough
 		gRoute.data.dstLen === 0 && gRoute.attrs.gateway &&
-		true //lRoute.attrs.dst.readUint32BE() === addrPrefix && lRoute.data.dstLen === addr[1]
+		extraRoutes.every(route => route.data.dstLen !== 0 && !route.attrs.gateway)
 	))
 		throw Error('unexpected route configuration');
 	const gatewayAddr = gRoute.attrs.gateway.readUint32BE();

--- a/lib/NetworkUtils.js
+++ b/lib/NetworkUtils.js
@@ -170,7 +170,7 @@ const collectCandidateInfo = (ip, port, ifindex) => withSocket(async rtNetlink =
 	// to handle weird setups as good as possible, it's important to pass all
 	// relevant info (protocol, destination port, ToS, mark, UID...)
 
-	const { attrs: { gateway, prefsrc, oif } } = await rtNetlink.getRoute(
+	const { data: { scope }, attrs: { gateway, prefsrc, oif } } = await rtNetlink.getRoute(
 		{ family: 2, flags: { fibMatch: true } },
 		{ dst: be32(ip), ipProto: Buffer.of(IPPROTO_UDP), dport: be16(port) })
 		.then(
@@ -178,7 +178,7 @@ const collectCandidateInfo = (ip, port, ifindex) => withSocket(async rtNetlink =
 			err => Promise.reject(new Error(`routing failed: ${err}`))
 		);
 
-	if (!(oif !== undefined && prefsrc !== undefined))
+	if (!(oif !== undefined))
 		throw Error('expected route attributes not present')
 	// reject if the candidate would be routed to a different interface.
 	// in addition to this, we could force the FIB lookup to use a specific
@@ -186,11 +186,31 @@ const collectCandidateInfo = (ip, port, ifindex) => withSocket(async rtNetlink =
 	if (oif !== ifindex)
 		throw Error(`candidate would be routed to interface ${oif}, not ${ifindex}`)
 
-	const src = prefsrc.readUInt32BE();
+	// deciding the next hop from the matched route isn't straightforward. there
+	// are lots of edge cases for historical reasons, and apparently no way for
+	// us to ask Linux so we need to replicate it. we'll just skip most of the
+	// edge cases so this should be good enough
 	const dst = gateway !== undefined ? gateway.readUInt32BE() : ip;
 
+	// as for source: to replicate Linux we should use prefsrc if present, otherwise
+	// inet_select_addr() is called, which we are somehow imitating here
+	let src = prefsrc && prefsrc.readUInt32BE();
+	if (!src) {
+		const localnetScope = netlink.rt.RouteScope.HOST;
+		const parseAddress = addr => [ addr.attrs.address.readUInt32BE(), addr.data.prefixlen ]
+		const addresses = await rtNetlink.getAddresses({ family: 2, index: ifindex });
+		const matches = addresses.filter(addr => 
+			!addr.data.flags.secondary &&
+			Math.min(addr.data.scope, localnetScope) <= netlink.rt.RouteScope[scope] &&
+			isInsidePrefix(parseAddress(addr), [dst, 32]));
+		const selected = matches[0] || addresses[0];
+		if (!selected)
+			throw Error('source selection failed');
+		src = selected.attrs.local.readUInt32BE();
+	}
 
-	// PART 2: obtain MAC of target L2 host
+
+	// PART 2: obtain MAC of next hop
 
 	// subscribe to neighbor table updates (make sure to ref socket to hold loop alive)
 	rtNetlink.socket.ref();

--- a/lib/NetworkUtils.js
+++ b/lib/NetworkUtils.js
@@ -67,38 +67,26 @@ const netlink = (() => {
 	} catch (e) {}
 })();
 
-// use a single, shared socket for queries
-/** @type {import('netlink').RtNetlinkSocket} */
-let rtNetlink;
-
-function ensureSharedSocket()
+/**
+ * Create a dedicated socket on each query, no caching... it's inefficient
+ * but more robust, we don't need to give user a way to invalidate the cache,
+ * we don't need to be careful when managing refs, subscriptions...
+ * @template T
+ * @param {(socket: import('netlink').RtNetlinkSocket) => PromiseLike<T>} callback
+ */
+async function withSocket(callback)
 {
-	if (rtNetlink)
-		return;
 	if (!netlink)
 		throw Error('netlink unavailable or failed to import');
-	rtNetlink = netlink.createRtNetlink();
-}
-
-// cache responses for a while, to avoid collapsing socket
-/** @type {Map<string, ReturnType<typeof realGetInterfaceRawConfig>>} */
-const rawConfigCache = new Map()
-
-function getInterfaceRawConfig(name)
-{
-	let promise = rawConfigCache.get(name);
-	if (!promise) {
-		promise = realGetInterfaceRawConfig(name);
-		rawConfigCache.set(name, promise);
-		promise.then(() => delay(200), () => {}).then(() => rawConfigCache.delete(name));
+	const rtNetlink = netlink.createRtNetlink();
+	try {
+		return await callback(rtNetlink);
+	} finally {
+		rtNetlink.socket.close();
 	}
-	return promise;
 }
 
-async function realGetInterfaceRawConfig(name)
-{
-	ensureSharedSocket();
-
+const getInterfaceRawConfig = (name, rtNetlink) => withSocket(async rtNetlink => {
 	// fetch link
 	const [ link ] = await rtNetlink.getLink({}, { ifname: name })
 		.catch(error => { throw Error(`failed to find interface ${name}: ${error}`) });
@@ -142,7 +130,7 @@ async function realGetInterfaceRawConfig(name)
 		throw Error('gateway ARP entry not found');
 
 	return { index, addr, lladdr: formatMac(lladdr), gatewayAddr, gatewayLladdr: formatMac(gatewayLladdr) };
-}
+});
 
 
 module.exports = {

--- a/lib/NetworkUtils.js
+++ b/lib/NetworkUtils.js
@@ -120,40 +120,15 @@ const getInterfaceRawConfig = (name, rtNetlink) => withSocket(async rtNetlink =>
 	if (!lladdr)
 		throw Error('no physical address found on interface');
 
-	// fetch IPv4 addresses
-	let addrs = (await rtNetlink.getAddresses())
-		.filter(addr => addr.data.family === 2 && addr.data.index === index)
-		.map(addr => [ addr.attrs.address.readUInt32BE(), addr.data.prefixlen ]);
-	if (addrs.length !== 1) {
-		// try to discard reserved addresses and see if there's just 1 address left
-		addrs = addrs.filter(x => !isReservedAddress(x));
-	}
-	if (addrs.length !== 1)
-		throw Error('multiple IPv4 addresses found');
-	const [ addr ] = addrs;
+	// fetch IPv4 routes, find default route, check there's a gateway, resolve it
+	const routes = (await rtNetlink.getRoutes())
+		.filter(route => route.data.family === 2 && route.attrs.oif === index && route.data.type === 'UNICAST') // filter ourselves, kernel seems to be buggy
+		.filter(route => route.data.dstLen === 0 && route.attrs.gateway);
+	const fallbackData = routes.length ? 
+		(await collectRoutingInfoWithRoute(rtNetlink, index, routes[0], routes[0].attrs.gateway.readUInt32BE())) :
+		[ 0, '00:00:00:00:00:00' ]; // silently give an invalid value
 
-	// fetch IPv4 routes
-	const [gRoute, ...extraRoutes] = (await rtNetlink.getRoutes())
-		.filter(route => route.data.family === 2 && route.attrs.oif === index && route.data.type === 'UNICAST')
-		.sort((a, b) => Number(a.data.dstLen !== 0)); // guarantee gateway goes first
-	const addrPrefix = (addr[0] & cidrMask(addr[1])) >>> 0;
-	if (!(
-		// some checks disabled for now since they don't play well, not flexible enough
-		gRoute.data.dstLen === 0 && gRoute.attrs.gateway &&
-		extraRoutes.every(route => route.data.dstLen !== 0 && !route.attrs.gateway)
-	))
-		throw Error('unexpected route configuration');
-	const gatewayAddr = gRoute.attrs.gateway.readUint32BE();
-
-	// fetch ARP entries (FIXME: be a bit more robust, probe if not found)
-	const neighbors = new Map((await rtNetlink.getNeighbors())
-		.filter(neigh => neigh.data.family === 2 && neigh.data.ifindex === index && neigh.data.state.reachable)
-		.map(neigh => [ neigh.attrs.dst.readUint32BE(), neigh.attrs.lladdr ]));
-	const gatewayLladdr = neighbors.get(gatewayAddr);
-	if (!gatewayLladdr)
-		throw Error('gateway ARP entry not found');
-
-	return { index, addr, lladdr: formatMac(lladdr), gatewayAddr, gatewayLladdr: formatMac(gatewayLladdr) };
+	return { index, lladdr: formatMac(lladdr), fallbackData };
 });
 
 const IPPROTO_UDP = 17
@@ -170,7 +145,7 @@ const collectCandidateInfo = (ip, port, ifindex) => withSocket(async rtNetlink =
 	// to handle weird setups as good as possible, it's important to pass all
 	// relevant info (protocol, destination port, ToS, mark, UID...)
 
-	const { data: { scope }, attrs: { gateway, prefsrc, oif } } = await rtNetlink.getRoute(
+	const route = await rtNetlink.getRoute(
 		{ family: 2, flags: { fibMatch: true } },
 		{ dst: be32(ip), ipProto: Buffer.of(IPPROTO_UDP), dport: be16(port) })
 		.then(
@@ -178,8 +153,8 @@ const collectCandidateInfo = (ip, port, ifindex) => withSocket(async rtNetlink =
 			err => Promise.reject(new Error(`routing failed: ${err}`))
 		);
 
-	if (!(oif !== undefined))
-		throw Error('expected route attributes not present')
+	const { attrs: { gateway, oif } } = route;
+
 	// reject if the candidate would be routed to a different interface.
 	// in addition to this, we could force the FIB lookup to use a specific
 	// output interface (in case the machine has multiple WANs, for instance)
@@ -191,6 +166,21 @@ const collectCandidateInfo = (ip, port, ifindex) => withSocket(async rtNetlink =
 	// us to ask Linux so we need to replicate it. we'll just skip most of the
 	// edge cases so this should be good enough
 	const dst = gateway !== undefined ? gateway.readUInt32BE() : ip;
+
+	return await collectRoutingInfoWithRoute(rtNetlink, ifindex, route, dst);
+});
+
+/**
+ * Continuation of collectRoutingInfo once a route has been
+ * selected (split to allow reusal from getInterfaceRawConfig).
+ * 
+ * @param {import('netlink').RtNetlinkSocket} rtNetlink
+ * @param {number} ifindex Interface
+ * @param {import('netlink').rt.RouteMessage} route Selected route
+ * @param {number} dst Resolved next hop address for route
+ */
+const collectRoutingInfoWithRoute = async (rtNetlink, ifindex, route, dst) => {
+	const { data: { scope }, attrs: { prefsrc } } = route;
 
 	// as for source: to replicate Linux we should use prefsrc if present, otherwise
 	// inet_select_addr() is called, which we are somehow imitating here
@@ -255,7 +245,7 @@ const collectCandidateInfo = (ip, port, ifindex) => withSocket(async rtNetlink =
 	if (state && (state.permanent || state.reachable || state.stale || state.delay))
 		return [ src, formatMac(entry.attrs.lladdr) ];
 	throw Error(`unexpected ARP state: ${util.inspect(state)}`);
-});
+};
 
 
 module.exports = {

--- a/lib/NetworkUtils.js
+++ b/lib/NetworkUtils.js
@@ -3,6 +3,16 @@ const util = require('util');
 const delay = util.promisify(setTimeout);
 
 
+// Utilities to manipulate MAC addresses
+
+function formatMac(mac)
+{
+	if (!(mac instanceof Uint8Array && mac.length === 6))
+		throw TypeError('invalid MAC address');
+	return [...mac].map(x => x.toString(16).padStart(2, '0')).join(':');
+}
+
+
 // Utilities to manipulate IPv4 addresses
 
 /** parse a CIDR into a normalized [address as u32be, prefix length] tuple */
@@ -10,7 +20,7 @@ function parseCIDR(cidr)
 {
 	cidr = /^((?:\d+\.){3}\d+)\/(\d+)$/.exec(cidr);
 	if (!cidr)
-		throw Error(`invalid CIDR: ${cidr}`)
+		throw Error(`invalid CIDR: ${cidr}`);
 	const [addr, prefix] = cidr.slice(1);
 	const verifyRange = (x, max) => {
 		x = parseInt(x);
@@ -131,7 +141,7 @@ async function realGetInterfaceRawConfig(name)
 	if (!gatewayLladdr)
 		throw Error('gateway ARP entry not found');
 
-	return { index, addr, lladdr, gatewayAddr, gatewayLladdr };
+	return { index, addr, lladdr: formatMac(lladdr), gatewayAddr, gatewayLladdr: formatMac(gatewayLladdr) };
 }
 
 

--- a/lib/NetworkUtils.js
+++ b/lib/NetworkUtils.js
@@ -1,6 +1,22 @@
 //@ts-check
 const util = require('util');
-const delay = util.promisify(setTimeout);
+const dgram = require('dgram');
+const events = require('events');
+
+const be32 = (x) => {
+	if (x !== (x >>> 0))
+		throw Error(`not a u32: ${x}`)
+	const r = Buffer.alloc(4);
+	r.writeUInt32BE(x);
+	return r;
+}
+const be16 = (x) => {
+	if (x !== (x & 0xFFFF))
+		throw Error(`not a u16: ${x}`)
+	const r = Buffer.alloc(2);
+	r.writeUInt16BE(x);
+	return r;
+}
 
 
 // Utilities to manipulate MAC addresses
@@ -15,21 +31,29 @@ function formatMac(mac)
 
 // Utilities to manipulate IPv4 addresses
 
+const verifyRange = (x, max) => {
+	x = parseInt(x);
+	if (x > max)
+		throw Error(`${x} exceeds ${max}`);
+	return x;
+}
+
+/** parse a dot-separated IPv4 into a normalized address as u32be */
+function parseIPv4(ip)
+{
+	if (!/^(?:\d+\.){3}\d+$/.test(ip))
+		throw Error(`invalid IPv4: ${ip}`);
+	const rawAddr = Buffer.from(ip.split('.').map(x => verifyRange(x, 255)));
+	return rawAddr.readUInt32BE();
+}
+
 /** parse a CIDR into a normalized [address as u32be, prefix length] tuple */
 function parseCIDR(cidr)
 {
-	cidr = /^((?:\d+\.){3}\d+)\/(\d+)$/.exec(cidr);
-	if (!cidr)
+	if (!/^[^/]+\/\d+$/.exec(cidr))
 		throw Error(`invalid CIDR: ${cidr}`);
-	const [addr, prefix] = cidr.slice(1);
-	const verifyRange = (x, max) => {
-		x = parseInt(x);
-		if (x > max)
-			throw Error(`${x} exceeds ${max}`);
-		return x;
-	}
-	const rawAddr = Buffer.from(addr.split('.').map(x => verifyRange(x, 255)));
-	return [rawAddr.readUInt32BE(), verifyRange(prefix, 32)];
+	const [addr, prefix] = cidr.split('/');
+	return [parseIPv4(addr), verifyRange(prefix, 32)];
 }
 
 const cidrMask = (n) => (~0) << (32 - n);
@@ -132,7 +156,89 @@ const getInterfaceRawConfig = (name, rtNetlink) => withSocket(async rtNetlink =>
 	return { index, addr, lladdr: formatMac(lladdr), gatewayAddr, gatewayLladdr: formatMac(gatewayLladdr) };
 });
 
+const IPPROTO_UDP = 17
+
+/** @type {<T>(list: T[], name: string) => T | Promise<T>} */
+const extractOne = (list, name) =>
+	list.length === 1 ? list[0] : Promise.reject(`expected one ${name}, ${list.length} returned`);
+
+const collectCandidateInfo = (ip, port, ifindex) => withSocket(async rtNetlink => {
+	ip = parseIPv4(ip);
+
+
+	// PART 1: perform a FIB lookup to see where Linux routes this candidate at.
+	// to handle weird setups as good as possible, it's important to pass all
+	// relevant info (protocol, destination port, ToS, mark, UID...)
+
+	const { attrs: { gateway, prefsrc, oif } } = await rtNetlink.getRoute(
+		{ family: 2, flags: { fibMatch: true } },
+		{ dst: be32(ip), ipProto: Buffer.of(IPPROTO_UDP), dport: be16(port) })
+		.then(
+			res => extractOne(res, 'route'),
+			err => Promise.reject(new Error(`routing failed: ${err}`))
+		);
+
+	if (!(oif !== undefined && prefsrc !== undefined))
+		throw Error('expected route attributes not present')
+	// reject if the candidate would be routed to a different interface.
+	// in addition to this, we could force the FIB lookup to use a specific
+	// output interface (in case the machine has multiple WANs, for instance)
+	if (oif !== ifindex)
+		throw Error(`candidate would be routed to interface ${oif}, not ${ifindex}`)
+
+	const src = prefsrc.readUInt32BE();
+	const dst = gateway !== undefined ? gateway.readUInt32BE() : ip;
+
+
+	// PART 2: obtain MAC of target L2 host
+
+	// subscribe to neighbor table updates (make sure to ref socket to hold loop alive)
+	rtNetlink.socket.ref();
+	rtNetlink.socket.addMembership(netlink.rt.MulticastGroups.NEIGH);
+
+	// once subscription is active, obtain current ARP entry (if any)
+	let entry = await rtNetlink.getNeighbor({ family: 2, ifindex }, { dst: be32(dst) })
+		.then(
+			res => extractOne(res, 'neighbor'),
+			err => (err && err.message === 'Request rejected: ENOENT') ? undefined : Promise.reject(err)
+		);
+
+	// if needed, trigger an ARP probe
+	let state = entry && entry.data.state;
+	if (!state) {
+		const udpSocket = dgram.createSocket('udp4');
+		udpSocket.connect(1, be32(dst).join('.'));
+		await events.once(udpSocket, 'connect');
+		await util.promisify(cb => udpSocket.send('', cb))();
+
+		// re-obtain the entry, should now be in probing state
+		entry = await rtNetlink.getNeighbor({ family: 2, ifindex }, { dst: be32(dst) })
+			.then(res => extractOne(res, 'neighbor'));
+	}
+
+	// if needed, wait until (re)probing finishes
+	while (state = entry && entry.data.state, state && (state.incomplete || state.probe)) {
+		// wait for next update of this entry
+		while (true) {
+			const [msg] = await events.once(rtNetlink, 'message');
+			entry = msg.find(msg =>
+				msg.kind === 'neighbor' && msg.data.family === 2 && msg.data.ifindex === ifindex &&
+				msg.attrs.dst.readUInt32BE() === dst);
+			if (entry) break;
+		}
+	}
+
+	// check result of probe
+	state = entry && entry.data.state;
+	if (state && (state.failed || state.noarp))
+		throw Error('ARP probe failed');
+	if (state && (state.permanent || state.reachable || state.stale || state.delay))
+		return [ src, formatMac(entry.attrs.lladdr) ];
+	throw Error(`unexpected ARP state: ${util.inspect(state)}`);
+});
+
 
 module.exports = {
 	getInterfaceRawConfig : getInterfaceRawConfig,
+	collectCandidateInfo : collectCandidateInfo,
 };

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -50,7 +50,7 @@ class Transport
 			throw new Error("You must provide remote ice and dtls info");
 		
 		//Store remote properties
-		this.remote = remote;
+		this.remote = { ...remote, candidates: [] };
 		
 		//Create local info
 		this.local = local;
@@ -166,7 +166,7 @@ class Transport
 			throw new Error("Could not create native transport");
 		
 		//Add remote candidates
-		this.addRemoteCandidates(this.remote.candidates || []);
+		this.addRemoteCandidates(remote.candidates || []);
 		
 		//List of streams
 		this.incomingStreams = new Map();
@@ -526,17 +526,17 @@ class Transport
 			port = candidate.getPort();
 		}
 		//Create new candidate on bundle for this transport
-		const ok = this.bundle.AddRemoteCandidate(this.username, ip, port);
+		if (!this.bundle.AddRemoteCandidate(this.username, ip, port))
+			return false;
 
-		//Add candidate to remote ones, if not already present
-		if (ok && !this.remote.candidates.includes(candidate))
-			this.remote.candidates.push(candidate.clone());
+		//Add candidate to remote list
+		this.remote.candidates.push(candidate.clone());
 
 		//Collect and set raw TX data, if raw TX is active
-		if (ok)
-			this.setCandidateRawTxData(ip, port).catch(e => this.emit('rawtxdataerror', ip, port, e));
+		//TODO: Change addRemoteCandidate to async
+		this.setCandidateRawTxData(ip, port).catch(e => this.emit('rawtxdataerror', ip, port, e));
 
-		return ok;
+		return true;
 	}
 
 	async setCandidateRawTxData(ip, port)

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -164,27 +164,8 @@ class Transport
 			//error
 			throw new Error("Could not create native transport");
 		
-		//For each remote candidate
-		for (let i=0;this.remote.candidates && i<this.remote.candidates.length;++i)
-		{
-			let ip,port;
-			//Get candidate
-			const candidate = this.remote.candidates[i];
-			
-			//If it is a relay candidate
-			if ("relay"===candidate.getType())
-			{
-				//Get relay ip and port
-				ip   = candidate.getRelAddr();
-				port = candidate.getRelPort();
-			} else {
-				//Get ip and port
-				ip   = candidate.getAddress();
-				port = candidate.getPort();
-			}
-			//Create new candidate on bundle for this transport
-			this.bundle.AddRemoteCandidate(this.username, ip, port);
-		}
+		//Add remote candidates
+		this.addRemoteCandidates(this.remote.candidates || []);
 		
 		//List of streams
 		this.incomingStreams = new Map();
@@ -544,15 +525,13 @@ class Transport
 			port = candidate.getPort();
 		}
 		//Create new candidate on bundle for this transport
-		if (!this.bundle.AddRemoteCandidate(this.username, ip, port))
-			//Already present
-			return false;
-		
-		//Add candidate to remote ones
-		this.remote.candidates.push(candidate.clone());
-		//Ok
-		return true;
-		
+		const ok = this.bundle.AddRemoteCandidate(this.username, ip, port);
+
+		//Add candidate to remote ones, if not already present
+		if (ok && !this.remote.candidates.includes(candidate))
+			this.remote.candidates.push(candidate.clone());
+
+		return ok;
 	}
 	
 	/**

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -534,7 +534,7 @@ class Transport
 
 		//Collect and set raw TX data, if raw TX is active
 		if (ok)
-			this.setCandidateRawTxData(ip, port);
+			this.setCandidateRawTxData(ip, port).catch(e => this.emit('rawtxdataerror', ip, port, e));
 
 		return ok;
 	}

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -1,4 +1,5 @@
 const Native		= require("./Native");
+const NetworkUtils	= require("./NetworkUtils");
 const EventEmitter	= require('events').EventEmitter;
 const LFSR		= require('lfsr');
 const uuidV4		= require('uuid/v4');
@@ -531,7 +532,24 @@ class Transport
 		if (ok && !this.remote.candidates.includes(candidate))
 			this.remote.candidates.push(candidate.clone());
 
+		//Collect and set raw TX data, if raw TX is active
+		if (ok)
+			this.setCandidateRawTxData(ip, port);
+
 		return ok;
+	}
+
+	async setCandidateRawTxData(ip, port)
+	{
+		const ifindex = this.bundle.rawTxInterface;
+		if (ifindex === undefined)
+			return;
+
+		//If raw TX is currently active in the bundle, fetch raw TX data for this candidate from OS
+		const rawTxData = await NetworkUtils.collectCandidateInfo(ip, port, ifindex);
+
+		//Send data to endpoint thread
+		return this.bundle.SetCandidateRawTxData(ip, port, ...rawTxData);
 	}
 	
 	/**

--- a/medooze-media-server.d.ts
+++ b/medooze-media-server.d.ts
@@ -914,7 +914,7 @@ import SemanticSDP = require('semantic-sdp');
      */
     setRawTx(options: false | {
       /** (required) name of interface to send on */
-      interface: string
+      interfaceName: string
       /** whether to skip the traffic shaping (qdisc) on the interface */
       skipQdisc?: boolean
       /** AF_PACKET socket send queue */

--- a/medooze-media-server.d.ts
+++ b/medooze-media-server.d.ts
@@ -365,6 +365,13 @@ import SemanticSDP = require('semantic-sdp');
     outgoingtrack(track: OutgoingStreamTrack, stream: OutgoingStream|null): void;
     incomingtrack(track: IncomingStreamTrack, stream: IncomingStream|null): void;
     stopped(transport: Transport): void;
+
+    /**
+     * [EXPERIMENTAL] This option is currently Linux-specific and undocumented. Use at your own risk.
+     *
+     * Error occurred when calling [[setCandidateRawTxData]] automatically. See [[Endpoint.setRawTx]].
+     */
+    rawtxdataerror(ip: string, port: number, error: any): void;
   }
 
   export interface Transport {
@@ -462,6 +469,13 @@ import SemanticSDP = require('semantic-sdp');
      * @param {Array.CandidateInfo} candidates
      */
     addRemoteCandidates(candidates: SemanticSDP.CandidateInfo[]): void;
+
+    /**
+     * [EXPERIMENTAL] This option is currently Linux-specific and undocumented. Use at your own risk.
+     *
+     * Refresh the raw TX data for a candidate. See [[Endpoint.setRawTx]].
+     */
+    setCandidateRawTxData(ip, port): Promise<void>
 
     /**
      * Create new outgoing stream in this transport
@@ -873,45 +887,7 @@ import SemanticSDP = require('semantic-sdp');
     setAffinity(cpu: number): boolean;
   
     /**
-     * [EXPERIMENTAL] This option is currently Linux-specific and unsafe to use. Its semantics and API are subject to change even in patch versions.
-     *
-     * Causes the endpoint to send packets directly as Ethernet frames using AF_PACKET sockets, thus skipping most of Linux network stack.
-     *
-     * The interface is assumed to be Ethernet. Basic information (MAC address) is collected about it, an AF_PACKET socket is bound to it,
-     * and the endpoint switches to it for transmission. Should that information become obsolete, or the interface disappear / go down,
-     * it's the user's responsibility to call [[setRawTx]] again (to either reconfigure or disable raw TX).
-     *
-     * When active, calls to [[addRemoteCandidate]] request info to the OS about how traffic to that IP is routed, as well as the
-     * corresponding entry in the ARP table. If the candidate would be routed to a different interface, [[addRemoteCandidate]] rejects it.
-     * Otherwise, the target MAC and the source IP (in case the interface has multiple IPs) are saved together with the candidate.
-     * Should this information become obsolete (i.e. because routing changed, interface IP changed, or target host / gateway changed its
-     * MAC address) it's the user's responsibility to call [[addRemoteCandidate]] again so the information is requested & saved again,
-     * overwriting the existing one.
-     *
-     * Other things to keep in mind:
-     *
-     * - Transmitting raw packets usually requires CAP_NET_RAW or root.
-     *
-     * - When active, traffic is only sent from candidates added via [[addRemoteCandidate]] when this option was active (since they have
-     *   the associated info). For candidates not added via [[addRemoteCandidate]] or added when the option was not active, their traffic
-     *   will be silently dropped until you call [[addRemoteCandidate]] to collect & save info in them. Info is never removed from
-     *   candidates, even if raw TX is later disabled.
-     *
-     * - Since the network stack is skipped, outgoing packets will not be affected by cgroups, firewall, NAT, connection tracking, routing, etc.
-     *   The qdisc (traffic shaping) can optionally be bypassed as well.
-     *
-     *   * If the qdisc is skipped, maxing the interface's bandwidth may cause increased drops, also in traffic coming from the OS.
-     *
-     *   [[addRemoteCandidate]] will essentially simulate routing and may reject or even miss nuances in your setup. If missed, open an issue.
-     *
-     * - [[addRemoteCandidate]] will sometimes take a significant time (seconds) to resolve, while probing finishes. To prevent delays in most
-     *   cases, **stale ARP entries will be accepted as if they were up to date**. [[addRemoteCandidate]] may send an empty packet to the host /
-     *   gateway to attempt triggering an ARP probe. [[addRemoteCandidate]] will reject if routing or ARP probing fails.
-     *
-     * - The data collection requires Linux 5.0+.
-     * 
-     * This function throws if (re)configuration fails (because the necessary modules weren't found, insufficient privileges, unexpected network configuration, etc.).
-     * In case of failure, configuration is left unchanged.
+     * [EXPERIMENTAL] This option is currently Linux-specific and undocumented. Use at your own risk.
      * 
      * @param options Options for raw TX. Pass false to disable.
      */

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "semantic-sdp": "^3",
     "uuid": "^3.3.2"
   },
+  "optionalDependencies": {
+    "netlink": "0.2.3"
+  },
   "devDependencies": {
     "documentation": "13.2.5",
     "tap": "^14"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "uuid": "^3.3.2"
   },
   "optionalDependencies": {
-    "netlink": "0.2.3"
+    "netlink": "0.2.4"
   },
   "devDependencies": {
     "documentation": "13.2.5",

--- a/src/media-server.i
+++ b/src/media-server.i
@@ -1065,7 +1065,7 @@ public:
 			SWIG_exception_fail(SWIG_TypeError, "in method '" "$symname" "', argument ""$argnum"" of type '" "$type""'");
 		asArray->CopyContents(($1).data(), 6);
 	}
-	void SetRawTx(int32_t ifindex, unsigned int sndbuf, bool skipQdisc, uint32_t self_addr, uint32_t prefixlen, RawTxHelper::MacAddr self_lladdr, uint32_t gw_addr, RawTxHelper::MacAddr gw_lladdr, uint16_t port);
+	void SetRawTx(int32_t ifindex, unsigned int sndbuf, bool skipQdisc, uint32_t selfAddr, uint32_t prefixlen, RawTxHelper::MacAddr selfLladdr, uint32_t gwAddr, RawTxHelper::MacAddr gwLladdr, uint16_t port);
 	void ClearRawTx();
 
 	bool SetAffinity(int cpu);

--- a/src/media-server.i
+++ b/src/media-server.i
@@ -1049,6 +1049,7 @@ public:
 	int End();
 	int GetLocalPort() const { return port; }
 	int AddRemoteCandidate(const std::string& username,const char* ip, WORD port);		
+	void SetCandidateRawTxData(const std::string& ip, uint16_t port, uint32_t selfAddr, const std::string& dstLladdr);
 
 	%exception SetRawTx {
 		try {

--- a/src/media-server.i
+++ b/src/media-server.i
@@ -1057,15 +1057,7 @@ public:
 			SWIG_exception(SWIG_SystemError, exc.what());
 		}
 	}
-	%typemap(in) RawTxHelper::MacAddr {
-		if (!($input)->IsUint8Array())
-			SWIG_exception_fail(SWIG_TypeError, "in method '" "$symname" "', argument ""$argnum"" of type '" "$type""'");
-		auto asArray = ($input).As<v8::Uint8Array>();
-		if (asArray->Length() != 6)
-			SWIG_exception_fail(SWIG_TypeError, "in method '" "$symname" "', argument ""$argnum"" of type '" "$type""'");
-		asArray->CopyContents(($1).data(), 6);
-	}
-	void SetRawTx(int32_t ifindex, unsigned int sndbuf, bool skipQdisc, uint32_t selfAddr, uint32_t prefixlen, RawTxHelper::MacAddr selfLladdr, uint32_t gwAddr, RawTxHelper::MacAddr gwLladdr, uint16_t port);
+	void SetRawTx(int32_t ifindex, unsigned int sndbuf, bool skipQdisc, uint32_t selfAddr, uint32_t prefixlen, const std::string& selfLladdr, uint32_t gwAddr, const std::string& gwLladdr, uint16_t port);
 	void ClearRawTx();
 
 	bool SetAffinity(int cpu);

--- a/src/media-server.i
+++ b/src/media-server.i
@@ -817,6 +817,7 @@ private:
 %include "stdint.i"
 %include "std_string.i"
 %include "std_vector.i"
+%include "exception.i"
 #define QWORD		uint64_t
 #define DWORD		uint32_t
 #define WORD		uint16_t
@@ -1048,6 +1049,25 @@ public:
 	int End();
 	int GetLocalPort() const { return port; }
 	int AddRemoteCandidate(const std::string& username,const char* ip, WORD port);		
+
+	%exception SetRawTx {
+		try {
+			$action
+		} catch (std::system_error& exc) {
+			SWIG_exception(SWIG_SystemError, exc.what());
+		}
+	}
+	%typemap(in) RawTxHelper::MacAddr {
+		if (!($input)->IsUint8Array())
+			SWIG_exception_fail(SWIG_TypeError, "in method '" "$symname" "', argument ""$argnum"" of type '" "$type""'");
+		auto asArray = ($input).As<v8::Uint8Array>();
+		if (asArray->Length() != 6)
+			SWIG_exception_fail(SWIG_TypeError, "in method '" "$symname" "', argument ""$argnum"" of type '" "$type""'");
+		asArray->CopyContents(($1).data(), 6);
+	}
+	void SetRawTx(int32_t ifindex, unsigned int sndbuf, bool skipQdisc, uint32_t self_addr, uint32_t prefixlen, RawTxHelper::MacAddr self_lladdr, uint32_t gw_addr, RawTxHelper::MacAddr gw_lladdr, uint16_t port);
+	void ClearRawTx();
+
 	bool SetAffinity(int cpu);
 	bool SetThreadName(const std::string& name);
 	bool SetPriority(int priority);

--- a/src/media-server.i
+++ b/src/media-server.i
@@ -1058,7 +1058,7 @@ public:
 			SWIG_exception(SWIG_SystemError, exc.what());
 		}
 	}
-	void SetRawTx(int32_t ifindex, unsigned int sndbuf, bool skipQdisc, const std::string& selfLladdr, uint32_t fallbackSelfAddr, const std::string& fallbackDstLladdr, uint16_t port);
+	void SetRawTx(int32_t ifindex, unsigned int sndbuf, bool skipQdisc, const std::string& selfLladdr, uint32_t defaultSelfAddr, const std::string& defaultDstLladdr, uint16_t port);
 	void ClearRawTx();
 
 	bool SetAffinity(int cpu);

--- a/src/media-server.i
+++ b/src/media-server.i
@@ -1058,7 +1058,7 @@ public:
 			SWIG_exception(SWIG_SystemError, exc.what());
 		}
 	}
-	void SetRawTx(int32_t ifindex, unsigned int sndbuf, bool skipQdisc, uint32_t selfAddr, uint32_t prefixlen, const std::string& selfLladdr, uint32_t gwAddr, const std::string& gwLladdr, uint16_t port);
+	void SetRawTx(int32_t ifindex, unsigned int sndbuf, bool skipQdisc, const std::string& selfLladdr, uint32_t fallbackSelfAddr, const std::string& fallbackDstLladdr, uint16_t port);
 	void ClearRawTx();
 
 	bool SetAffinity(int cpu);

--- a/src/media-server_wrap.cxx
+++ b/src/media-server_wrap.cxx
@@ -1371,25 +1371,24 @@ fail: ;
 #define SWIGTYPE_p_RTPSessionFacade swig_types[30]
 #define SWIGTYPE_p_RTPSource swig_types[31]
 #define SWIGTYPE_p_RTPStreamTransponderFacade swig_types[32]
-#define SWIGTYPE_p_RawTxHelper__MacAddr swig_types[33]
-#define SWIGTYPE_p_RemoteRateEstimatorListener swig_types[34]
-#define SWIGTYPE_p_SenderSideEstimatorListener swig_types[35]
-#define SWIGTYPE_p_SimulcastMediaFrameListener swig_types[36]
-#define SWIGTYPE_p_TimeService swig_types[37]
-#define SWIGTYPE_p_UDPDumper swig_types[38]
-#define SWIGTYPE_p_UDPReader swig_types[39]
-#define SWIGTYPE_p_char swig_types[40]
-#define SWIGTYPE_p_int swig_types[41]
-#define SWIGTYPE_p_long_long swig_types[42]
-#define SWIGTYPE_p_short swig_types[43]
-#define SWIGTYPE_p_signed_char swig_types[44]
-#define SWIGTYPE_p_unsigned_char swig_types[45]
-#define SWIGTYPE_p_unsigned_int swig_types[46]
-#define SWIGTYPE_p_unsigned_long_long swig_types[47]
-#define SWIGTYPE_p_unsigned_short swig_types[48]
-#define SWIGTYPE_p_v8__LocalT_v8__Object_t swig_types[49]
-static swig_type_info *swig_types[51];
-static swig_module_info swig_module = {swig_types, 50, 0, 0, 0, 0};
+#define SWIGTYPE_p_RemoteRateEstimatorListener swig_types[33]
+#define SWIGTYPE_p_SenderSideEstimatorListener swig_types[34]
+#define SWIGTYPE_p_SimulcastMediaFrameListener swig_types[35]
+#define SWIGTYPE_p_TimeService swig_types[36]
+#define SWIGTYPE_p_UDPDumper swig_types[37]
+#define SWIGTYPE_p_UDPReader swig_types[38]
+#define SWIGTYPE_p_char swig_types[39]
+#define SWIGTYPE_p_int swig_types[40]
+#define SWIGTYPE_p_long_long swig_types[41]
+#define SWIGTYPE_p_short swig_types[42]
+#define SWIGTYPE_p_signed_char swig_types[43]
+#define SWIGTYPE_p_unsigned_char swig_types[44]
+#define SWIGTYPE_p_unsigned_int swig_types[45]
+#define SWIGTYPE_p_unsigned_long_long swig_types[46]
+#define SWIGTYPE_p_unsigned_short swig_types[47]
+#define SWIGTYPE_p_v8__LocalT_v8__Object_t swig_types[48]
+static swig_type_info *swig_types[50];
+static swig_module_info swig_module = {swig_types, 49, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -8556,6 +8555,79 @@ fail:
 }
 
 
+static SwigV8ReturnValue _wrap_RTPBundleTransport_SetCandidateRawTxData(const SwigV8Arguments &args) {
+  SWIGV8_HANDLESCOPE();
+  
+  SWIGV8_VALUE jsresult;
+  RTPBundleTransport *arg1 = (RTPBundleTransport *) 0 ;
+  std::string *arg2 = 0 ;
+  uint16_t arg3 ;
+  uint32_t arg4 ;
+  std::string *arg5 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 = SWIG_OLDOBJ ;
+  unsigned short val3 ;
+  int ecode3 = 0 ;
+  unsigned int val4 ;
+  int ecode4 = 0 ;
+  int res5 = SWIG_OLDOBJ ;
+  
+  if(args.Length() != 4) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for _wrap_RTPBundleTransport_SetCandidateRawTxData.");
+  
+  res1 = SWIG_ConvertPtr(args.Holder(), &argp1,SWIGTYPE_p_RTPBundleTransport, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "RTPBundleTransport_SetCandidateRawTxData" "', argument " "1"" of type '" "RTPBundleTransport *""'"); 
+  }
+  arg1 = reinterpret_cast< RTPBundleTransport * >(argp1);
+  {
+    std::string *ptr = (std::string *)0;
+    res2 = SWIG_AsPtr_std_string(args[0], &ptr);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "RTPBundleTransport_SetCandidateRawTxData" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "RTPBundleTransport_SetCandidateRawTxData" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    arg2 = ptr;
+  }
+  ecode3 = SWIG_AsVal_unsigned_SS_short(args[1], &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "RTPBundleTransport_SetCandidateRawTxData" "', argument " "3"" of type '" "uint16_t""'");
+  } 
+  arg3 = static_cast< uint16_t >(val3);
+  ecode4 = SWIG_AsVal_unsigned_SS_int(args[2], &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "RTPBundleTransport_SetCandidateRawTxData" "', argument " "4"" of type '" "uint32_t""'");
+  } 
+  arg4 = static_cast< uint32_t >(val4);
+  {
+    std::string *ptr = (std::string *)0;
+    res5 = SWIG_AsPtr_std_string(args[3], &ptr);
+    if (!SWIG_IsOK(res5)) {
+      SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "RTPBundleTransport_SetCandidateRawTxData" "', argument " "5"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "RTPBundleTransport_SetCandidateRawTxData" "', argument " "5"" of type '" "std::string const &""'"); 
+    }
+    arg5 = ptr;
+  }
+  (arg1)->SetCandidateRawTxData((std::string const &)*arg2,arg3,arg4,(std::string const &)*arg5);
+  jsresult = SWIGV8_UNDEFINED();
+  
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  
+  
+  if (SWIG_IsNewObj(res5)) delete arg5;
+  
+  SWIGV8_RETURN(jsresult);
+  
+  goto fail;
+fail:
+  SWIGV8_RETURN(SWIGV8_UNDEFINED());
+}
+
+
 static SwigV8ReturnValue _wrap_RTPBundleTransport_SetRawTx(const SwigV8Arguments &args) {
   SWIGV8_HANDLESCOPE();
   
@@ -8564,12 +8636,10 @@ static SwigV8ReturnValue _wrap_RTPBundleTransport_SetRawTx(const SwigV8Arguments
   int32_t arg2 ;
   unsigned int arg3 ;
   bool arg4 ;
-  uint32_t arg5 ;
+  std::string *arg5 = 0 ;
   uint32_t arg6 ;
-  RawTxHelper::MacAddr arg7 ;
-  uint32_t arg8 ;
-  RawTxHelper::MacAddr arg9 ;
-  uint16_t arg10 ;
+  std::string *arg7 = 0 ;
+  uint16_t arg8 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   int val2 ;
@@ -8578,16 +8648,14 @@ static SwigV8ReturnValue _wrap_RTPBundleTransport_SetRawTx(const SwigV8Arguments
   int ecode3 = 0 ;
   bool val4 ;
   int ecode4 = 0 ;
-  unsigned int val5 ;
-  int ecode5 = 0 ;
+  int res5 = SWIG_OLDOBJ ;
   unsigned int val6 ;
   int ecode6 = 0 ;
-  unsigned int val8 ;
+  int res7 = SWIG_OLDOBJ ;
+  unsigned short val8 ;
   int ecode8 = 0 ;
-  unsigned short val10 ;
-  int ecode10 = 0 ;
   
-  if(args.Length() != 9) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for _wrap_RTPBundleTransport_SetRawTx.");
+  if(args.Length() != 7) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for _wrap_RTPBundleTransport_SetRawTx.");
   
   res1 = SWIG_ConvertPtr(args.Holder(), &argp1,SWIGTYPE_p_RTPBundleTransport, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
@@ -8609,45 +8677,41 @@ static SwigV8ReturnValue _wrap_RTPBundleTransport_SetRawTx(const SwigV8Arguments
     SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "RTPBundleTransport_SetRawTx" "', argument " "4"" of type '" "bool""'");
   } 
   arg4 = static_cast< bool >(val4);
-  ecode5 = SWIG_AsVal_unsigned_SS_int(args[3], &val5);
-  if (!SWIG_IsOK(ecode5)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "RTPBundleTransport_SetRawTx" "', argument " "5"" of type '" "uint32_t""'");
-  } 
-  arg5 = static_cast< uint32_t >(val5);
+  {
+    std::string *ptr = (std::string *)0;
+    res5 = SWIG_AsPtr_std_string(args[3], &ptr);
+    if (!SWIG_IsOK(res5)) {
+      SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "RTPBundleTransport_SetRawTx" "', argument " "5"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "RTPBundleTransport_SetRawTx" "', argument " "5"" of type '" "std::string const &""'"); 
+    }
+    arg5 = ptr;
+  }
   ecode6 = SWIG_AsVal_unsigned_SS_int(args[4], &val6);
   if (!SWIG_IsOK(ecode6)) {
     SWIG_exception_fail(SWIG_ArgError(ecode6), "in method '" "RTPBundleTransport_SetRawTx" "', argument " "6"" of type '" "uint32_t""'");
   } 
   arg6 = static_cast< uint32_t >(val6);
   {
-    if (!(args[5])->IsUint8Array())
-    SWIG_exception_fail(SWIG_TypeError, "in method '" "RTPBundleTransport_SetRawTx" "', argument ""7"" of type '" "RawTxHelper::MacAddr""'");
-    auto asArray = (args[5]).As<v8::Uint8Array>();
-    if (asArray->Length() != 6)
-    SWIG_exception_fail(SWIG_TypeError, "in method '" "RTPBundleTransport_SetRawTx" "', argument ""7"" of type '" "RawTxHelper::MacAddr""'");
-    asArray->CopyContents((arg7).data(), 6);
+    std::string *ptr = (std::string *)0;
+    res7 = SWIG_AsPtr_std_string(args[5], &ptr);
+    if (!SWIG_IsOK(res7)) {
+      SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "RTPBundleTransport_SetRawTx" "', argument " "7"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "RTPBundleTransport_SetRawTx" "', argument " "7"" of type '" "std::string const &""'"); 
+    }
+    arg7 = ptr;
   }
-  ecode8 = SWIG_AsVal_unsigned_SS_int(args[6], &val8);
+  ecode8 = SWIG_AsVal_unsigned_SS_short(args[6], &val8);
   if (!SWIG_IsOK(ecode8)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode8), "in method '" "RTPBundleTransport_SetRawTx" "', argument " "8"" of type '" "uint32_t""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode8), "in method '" "RTPBundleTransport_SetRawTx" "', argument " "8"" of type '" "uint16_t""'");
   } 
-  arg8 = static_cast< uint32_t >(val8);
-  {
-    if (!(args[7])->IsUint8Array())
-    SWIG_exception_fail(SWIG_TypeError, "in method '" "RTPBundleTransport_SetRawTx" "', argument ""9"" of type '" "RawTxHelper::MacAddr""'");
-    auto asArray = (args[7]).As<v8::Uint8Array>();
-    if (asArray->Length() != 6)
-    SWIG_exception_fail(SWIG_TypeError, "in method '" "RTPBundleTransport_SetRawTx" "', argument ""9"" of type '" "RawTxHelper::MacAddr""'");
-    asArray->CopyContents((arg9).data(), 6);
-  }
-  ecode10 = SWIG_AsVal_unsigned_SS_short(args[8], &val10);
-  if (!SWIG_IsOK(ecode10)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode10), "in method '" "RTPBundleTransport_SetRawTx" "', argument " "10"" of type '" "uint16_t""'");
-  } 
-  arg10 = static_cast< uint16_t >(val10);
+  arg8 = static_cast< uint16_t >(val8);
   {
     try {
-      (arg1)->SetRawTx(arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10);
+      (arg1)->SetRawTx(arg2,arg3,arg4,(std::string const &)*arg5,arg6,(std::string const &)*arg7,arg8);
     } catch (std::system_error& exc) {
       SWIG_exception(SWIG_SystemError, exc.what());
     }
@@ -8657,9 +8721,9 @@ static SwigV8ReturnValue _wrap_RTPBundleTransport_SetRawTx(const SwigV8Arguments
   
   
   
+  if (SWIG_IsNewObj(res5)) delete arg5;
   
-  
-  
+  if (SWIG_IsNewObj(res7)) delete arg7;
   
   
   SWIGV8_RETURN(jsresult);
@@ -14594,7 +14658,6 @@ static swig_type_info _swigt__p_RTPSenderFacade = {"_p_RTPSenderFacade", "p_RTPS
 static swig_type_info _swigt__p_RTPSessionFacade = {"_p_RTPSessionFacade", "p_RTPSessionFacade|RTPSessionFacade *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_RTPSource = {"_p_RTPSource", "p_RTPSource|RTPSource *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_RTPStreamTransponderFacade = {"_p_RTPStreamTransponderFacade", "p_RTPStreamTransponderFacade|RTPStreamTransponderFacade *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_RawTxHelper__MacAddr = {"_p_RawTxHelper__MacAddr", "RawTxHelper::MacAddr *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_RemoteRateEstimatorListener = {"_p_RemoteRateEstimatorListener", "p_RemoteRateEstimatorListener|RemoteRateEstimatorListener *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_SenderSideEstimatorListener = {"_p_SenderSideEstimatorListener", "p_SenderSideEstimatorListener", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_SimulcastMediaFrameListener = {"_p_SimulcastMediaFrameListener", "p_SimulcastMediaFrameListener|SimulcastMediaFrameListener *", 0, 0, (void*)0, 0};
@@ -14646,7 +14709,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_RTPSessionFacade,
   &_swigt__p_RTPSource,
   &_swigt__p_RTPStreamTransponderFacade,
-  &_swigt__p_RawTxHelper__MacAddr,
   &_swigt__p_RemoteRateEstimatorListener,
   &_swigt__p_SenderSideEstimatorListener,
   &_swigt__p_SimulcastMediaFrameListener,
@@ -14698,7 +14760,6 @@ static swig_cast_info _swigc__p_RTPSenderFacade[] = {  {&_swigt__p_RTPSenderFaca
 static swig_cast_info _swigc__p_RTPSessionFacade[] = {  {&_swigt__p_RTPSessionFacade, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_RTPSource[] = {  {&_swigt__p_RTPSource, 0, 0, 0},  {&_swigt__p_RTPIncomingSource, _p_RTPIncomingSourceTo_p_RTPSource, 0, 0},  {&_swigt__p_RTPOutgoingSource, _p_RTPOutgoingSourceTo_p_RTPSource, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_RTPStreamTransponderFacade[] = {  {&_swigt__p_RTPStreamTransponderFacade, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_RawTxHelper__MacAddr[] = {  {&_swigt__p_RawTxHelper__MacAddr, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_RemoteRateEstimatorListener[] = {  {&_swigt__p_RemoteRateEstimatorListener, 0, 0, 0},  {&_swigt__p_SenderSideEstimatorListener, _p_SenderSideEstimatorListenerTo_p_RemoteRateEstimatorListener, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_SenderSideEstimatorListener[] = {  {&_swigt__p_SenderSideEstimatorListener, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_SimulcastMediaFrameListener[] = {  {&_swigt__p_SimulcastMediaFrameListener, 0, 0, 0},{0, 0, 0, 0}};
@@ -14750,7 +14811,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_RTPSessionFacade,
   _swigc__p_RTPSource,
   _swigc__p_RTPStreamTransponderFacade,
-  _swigc__p_RawTxHelper__MacAddr,
   _swigc__p_RemoteRateEstimatorListener,
   _swigc__p_SenderSideEstimatorListener,
   _swigc__p_SimulcastMediaFrameListener,
@@ -15431,6 +15491,7 @@ SWIGV8_AddMemberFunction(_exports_RTPBundleTransport_class, "RemoveICETransport"
 SWIGV8_AddMemberFunction(_exports_RTPBundleTransport_class, "End", _wrap_RTPBundleTransport_End);
 SWIGV8_AddMemberFunction(_exports_RTPBundleTransport_class, "GetLocalPort", _wrap_RTPBundleTransport_GetLocalPort);
 SWIGV8_AddMemberFunction(_exports_RTPBundleTransport_class, "AddRemoteCandidate", _wrap_RTPBundleTransport_AddRemoteCandidate);
+SWIGV8_AddMemberFunction(_exports_RTPBundleTransport_class, "SetCandidateRawTxData", _wrap_RTPBundleTransport_SetCandidateRawTxData);
 SWIGV8_AddMemberFunction(_exports_RTPBundleTransport_class, "SetRawTx", _wrap_RTPBundleTransport_SetRawTx);
 SWIGV8_AddMemberFunction(_exports_RTPBundleTransport_class, "ClearRawTx", _wrap_RTPBundleTransport_ClearRawTx);
 SWIGV8_AddMemberFunction(_exports_RTPBundleTransport_class, "SetAffinity", _wrap_RTPBundleTransport_SetAffinity);

--- a/src/media-server_wrap.cxx
+++ b/src/media-server_wrap.cxx
@@ -1371,24 +1371,25 @@ fail: ;
 #define SWIGTYPE_p_RTPSessionFacade swig_types[30]
 #define SWIGTYPE_p_RTPSource swig_types[31]
 #define SWIGTYPE_p_RTPStreamTransponderFacade swig_types[32]
-#define SWIGTYPE_p_RemoteRateEstimatorListener swig_types[33]
-#define SWIGTYPE_p_SenderSideEstimatorListener swig_types[34]
-#define SWIGTYPE_p_SimulcastMediaFrameListener swig_types[35]
-#define SWIGTYPE_p_TimeService swig_types[36]
-#define SWIGTYPE_p_UDPDumper swig_types[37]
-#define SWIGTYPE_p_UDPReader swig_types[38]
-#define SWIGTYPE_p_char swig_types[39]
-#define SWIGTYPE_p_int swig_types[40]
-#define SWIGTYPE_p_long_long swig_types[41]
-#define SWIGTYPE_p_short swig_types[42]
-#define SWIGTYPE_p_signed_char swig_types[43]
-#define SWIGTYPE_p_unsigned_char swig_types[44]
-#define SWIGTYPE_p_unsigned_int swig_types[45]
-#define SWIGTYPE_p_unsigned_long_long swig_types[46]
-#define SWIGTYPE_p_unsigned_short swig_types[47]
-#define SWIGTYPE_p_v8__LocalT_v8__Object_t swig_types[48]
-static swig_type_info *swig_types[50];
-static swig_module_info swig_module = {swig_types, 49, 0, 0, 0, 0};
+#define SWIGTYPE_p_RawTxHelper__MacAddr swig_types[33]
+#define SWIGTYPE_p_RemoteRateEstimatorListener swig_types[34]
+#define SWIGTYPE_p_SenderSideEstimatorListener swig_types[35]
+#define SWIGTYPE_p_SimulcastMediaFrameListener swig_types[36]
+#define SWIGTYPE_p_TimeService swig_types[37]
+#define SWIGTYPE_p_UDPDumper swig_types[38]
+#define SWIGTYPE_p_UDPReader swig_types[39]
+#define SWIGTYPE_p_char swig_types[40]
+#define SWIGTYPE_p_int swig_types[41]
+#define SWIGTYPE_p_long_long swig_types[42]
+#define SWIGTYPE_p_short swig_types[43]
+#define SWIGTYPE_p_signed_char swig_types[44]
+#define SWIGTYPE_p_unsigned_char swig_types[45]
+#define SWIGTYPE_p_unsigned_int swig_types[46]
+#define SWIGTYPE_p_unsigned_long_long swig_types[47]
+#define SWIGTYPE_p_unsigned_short swig_types[48]
+#define SWIGTYPE_p_v8__LocalT_v8__Object_t swig_types[49]
+static swig_type_info *swig_types[51];
+static swig_module_info swig_module = {swig_types, 50, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -8555,6 +8556,147 @@ fail:
 }
 
 
+static SwigV8ReturnValue _wrap_RTPBundleTransport_SetRawTx(const SwigV8Arguments &args) {
+  SWIGV8_HANDLESCOPE();
+  
+  SWIGV8_VALUE jsresult;
+  RTPBundleTransport *arg1 = (RTPBundleTransport *) 0 ;
+  int32_t arg2 ;
+  unsigned int arg3 ;
+  bool arg4 ;
+  uint32_t arg5 ;
+  uint32_t arg6 ;
+  RawTxHelper::MacAddr arg7 ;
+  uint32_t arg8 ;
+  RawTxHelper::MacAddr arg9 ;
+  uint16_t arg10 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  unsigned int val3 ;
+  int ecode3 = 0 ;
+  bool val4 ;
+  int ecode4 = 0 ;
+  unsigned int val5 ;
+  int ecode5 = 0 ;
+  unsigned int val6 ;
+  int ecode6 = 0 ;
+  unsigned int val8 ;
+  int ecode8 = 0 ;
+  unsigned short val10 ;
+  int ecode10 = 0 ;
+  
+  if(args.Length() != 9) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for _wrap_RTPBundleTransport_SetRawTx.");
+  
+  res1 = SWIG_ConvertPtr(args.Holder(), &argp1,SWIGTYPE_p_RTPBundleTransport, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "RTPBundleTransport_SetRawTx" "', argument " "1"" of type '" "RTPBundleTransport *""'"); 
+  }
+  arg1 = reinterpret_cast< RTPBundleTransport * >(argp1);
+  ecode2 = SWIG_AsVal_int(args[0], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "RTPBundleTransport_SetRawTx" "', argument " "2"" of type '" "int32_t""'");
+  } 
+  arg2 = static_cast< int32_t >(val2);
+  ecode3 = SWIG_AsVal_unsigned_SS_int(args[1], &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "RTPBundleTransport_SetRawTx" "', argument " "3"" of type '" "unsigned int""'");
+  } 
+  arg3 = static_cast< unsigned int >(val3);
+  ecode4 = SWIG_AsVal_bool(args[2], &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "RTPBundleTransport_SetRawTx" "', argument " "4"" of type '" "bool""'");
+  } 
+  arg4 = static_cast< bool >(val4);
+  ecode5 = SWIG_AsVal_unsigned_SS_int(args[3], &val5);
+  if (!SWIG_IsOK(ecode5)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "RTPBundleTransport_SetRawTx" "', argument " "5"" of type '" "uint32_t""'");
+  } 
+  arg5 = static_cast< uint32_t >(val5);
+  ecode6 = SWIG_AsVal_unsigned_SS_int(args[4], &val6);
+  if (!SWIG_IsOK(ecode6)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode6), "in method '" "RTPBundleTransport_SetRawTx" "', argument " "6"" of type '" "uint32_t""'");
+  } 
+  arg6 = static_cast< uint32_t >(val6);
+  {
+    if (!(args[5])->IsUint8Array())
+    SWIG_exception_fail(SWIG_TypeError, "in method '" "RTPBundleTransport_SetRawTx" "', argument ""7"" of type '" "RawTxHelper::MacAddr""'");
+    auto asArray = (args[5]).As<v8::Uint8Array>();
+    if (asArray->Length() != 6)
+    SWIG_exception_fail(SWIG_TypeError, "in method '" "RTPBundleTransport_SetRawTx" "', argument ""7"" of type '" "RawTxHelper::MacAddr""'");
+    asArray->CopyContents((arg7).data(), 6);
+  }
+  ecode8 = SWIG_AsVal_unsigned_SS_int(args[6], &val8);
+  if (!SWIG_IsOK(ecode8)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode8), "in method '" "RTPBundleTransport_SetRawTx" "', argument " "8"" of type '" "uint32_t""'");
+  } 
+  arg8 = static_cast< uint32_t >(val8);
+  {
+    if (!(args[7])->IsUint8Array())
+    SWIG_exception_fail(SWIG_TypeError, "in method '" "RTPBundleTransport_SetRawTx" "', argument ""9"" of type '" "RawTxHelper::MacAddr""'");
+    auto asArray = (args[7]).As<v8::Uint8Array>();
+    if (asArray->Length() != 6)
+    SWIG_exception_fail(SWIG_TypeError, "in method '" "RTPBundleTransport_SetRawTx" "', argument ""9"" of type '" "RawTxHelper::MacAddr""'");
+    asArray->CopyContents((arg9).data(), 6);
+  }
+  ecode10 = SWIG_AsVal_unsigned_SS_short(args[8], &val10);
+  if (!SWIG_IsOK(ecode10)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode10), "in method '" "RTPBundleTransport_SetRawTx" "', argument " "10"" of type '" "uint16_t""'");
+  } 
+  arg10 = static_cast< uint16_t >(val10);
+  {
+    try {
+      (arg1)->SetRawTx(arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10);
+    } catch (std::system_error& exc) {
+      SWIG_exception(SWIG_SystemError, exc.what());
+    }
+  }
+  jsresult = SWIGV8_UNDEFINED();
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  SWIGV8_RETURN(jsresult);
+  
+  goto fail;
+fail:
+  SWIGV8_RETURN(SWIGV8_UNDEFINED());
+}
+
+
+static SwigV8ReturnValue _wrap_RTPBundleTransport_ClearRawTx(const SwigV8Arguments &args) {
+  SWIGV8_HANDLESCOPE();
+  
+  SWIGV8_VALUE jsresult;
+  RTPBundleTransport *arg1 = (RTPBundleTransport *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  
+  if(args.Length() != 0) SWIG_exception_fail(SWIG_ERROR, "Illegal number of arguments for _wrap_RTPBundleTransport_ClearRawTx.");
+  
+  res1 = SWIG_ConvertPtr(args.Holder(), &argp1,SWIGTYPE_p_RTPBundleTransport, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "RTPBundleTransport_ClearRawTx" "', argument " "1"" of type '" "RTPBundleTransport *""'"); 
+  }
+  arg1 = reinterpret_cast< RTPBundleTransport * >(argp1);
+  (arg1)->ClearRawTx();
+  jsresult = SWIGV8_UNDEFINED();
+  
+  
+  SWIGV8_RETURN(jsresult);
+  
+  goto fail;
+fail:
+  SWIGV8_RETURN(SWIGV8_UNDEFINED());
+}
+
+
 static SwigV8ReturnValue _wrap_RTPBundleTransport_SetAffinity(const SwigV8Arguments &args) {
   SWIGV8_HANDLESCOPE();
   
@@ -14452,6 +14594,7 @@ static swig_type_info _swigt__p_RTPSenderFacade = {"_p_RTPSenderFacade", "p_RTPS
 static swig_type_info _swigt__p_RTPSessionFacade = {"_p_RTPSessionFacade", "p_RTPSessionFacade|RTPSessionFacade *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_RTPSource = {"_p_RTPSource", "p_RTPSource|RTPSource *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_RTPStreamTransponderFacade = {"_p_RTPStreamTransponderFacade", "p_RTPStreamTransponderFacade|RTPStreamTransponderFacade *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_RawTxHelper__MacAddr = {"_p_RawTxHelper__MacAddr", "RawTxHelper::MacAddr *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_RemoteRateEstimatorListener = {"_p_RemoteRateEstimatorListener", "p_RemoteRateEstimatorListener|RemoteRateEstimatorListener *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_SenderSideEstimatorListener = {"_p_SenderSideEstimatorListener", "p_SenderSideEstimatorListener", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_SimulcastMediaFrameListener = {"_p_SimulcastMediaFrameListener", "p_SimulcastMediaFrameListener|SimulcastMediaFrameListener *", 0, 0, (void*)0, 0};
@@ -14503,6 +14646,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_RTPSessionFacade,
   &_swigt__p_RTPSource,
   &_swigt__p_RTPStreamTransponderFacade,
+  &_swigt__p_RawTxHelper__MacAddr,
   &_swigt__p_RemoteRateEstimatorListener,
   &_swigt__p_SenderSideEstimatorListener,
   &_swigt__p_SimulcastMediaFrameListener,
@@ -14554,6 +14698,7 @@ static swig_cast_info _swigc__p_RTPSenderFacade[] = {  {&_swigt__p_RTPSenderFaca
 static swig_cast_info _swigc__p_RTPSessionFacade[] = {  {&_swigt__p_RTPSessionFacade, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_RTPSource[] = {  {&_swigt__p_RTPSource, 0, 0, 0},  {&_swigt__p_RTPIncomingSource, _p_RTPIncomingSourceTo_p_RTPSource, 0, 0},  {&_swigt__p_RTPOutgoingSource, _p_RTPOutgoingSourceTo_p_RTPSource, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_RTPStreamTransponderFacade[] = {  {&_swigt__p_RTPStreamTransponderFacade, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_RawTxHelper__MacAddr[] = {  {&_swigt__p_RawTxHelper__MacAddr, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_RemoteRateEstimatorListener[] = {  {&_swigt__p_RemoteRateEstimatorListener, 0, 0, 0},  {&_swigt__p_SenderSideEstimatorListener, _p_SenderSideEstimatorListenerTo_p_RemoteRateEstimatorListener, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_SenderSideEstimatorListener[] = {  {&_swigt__p_SenderSideEstimatorListener, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_SimulcastMediaFrameListener[] = {  {&_swigt__p_SimulcastMediaFrameListener, 0, 0, 0},{0, 0, 0, 0}};
@@ -14605,6 +14750,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_RTPSessionFacade,
   _swigc__p_RTPSource,
   _swigc__p_RTPStreamTransponderFacade,
+  _swigc__p_RawTxHelper__MacAddr,
   _swigc__p_RemoteRateEstimatorListener,
   _swigc__p_SenderSideEstimatorListener,
   _swigc__p_SimulcastMediaFrameListener,
@@ -15285,6 +15431,8 @@ SWIGV8_AddMemberFunction(_exports_RTPBundleTransport_class, "RemoveICETransport"
 SWIGV8_AddMemberFunction(_exports_RTPBundleTransport_class, "End", _wrap_RTPBundleTransport_End);
 SWIGV8_AddMemberFunction(_exports_RTPBundleTransport_class, "GetLocalPort", _wrap_RTPBundleTransport_GetLocalPort);
 SWIGV8_AddMemberFunction(_exports_RTPBundleTransport_class, "AddRemoteCandidate", _wrap_RTPBundleTransport_AddRemoteCandidate);
+SWIGV8_AddMemberFunction(_exports_RTPBundleTransport_class, "SetRawTx", _wrap_RTPBundleTransport_SetRawTx);
+SWIGV8_AddMemberFunction(_exports_RTPBundleTransport_class, "ClearRawTx", _wrap_RTPBundleTransport_ClearRawTx);
 SWIGV8_AddMemberFunction(_exports_RTPBundleTransport_class, "SetAffinity", _wrap_RTPBundleTransport_SetAffinity);
 SWIGV8_AddMemberFunction(_exports_RTPBundleTransport_class, "SetThreadName", _wrap_RTPBundleTransport_SetThreadName);
 SWIGV8_AddMemberFunction(_exports_RTPBundleTransport_class, "SetPriority", _wrap_RTPBundleTransport_SetPriority);


### PR DESCRIPTION
high-level counterpart to medooze/media-server#121.

NetworkUtils.js handles pulling the necessary data about the network configuration from the OS. It also does some checks to prevent users from enabling the feature on setups where it wouldn't work correctly.

Endpoint.js exposes a high-level setRawTx(options) API, which only needs the interface name. It collects the necessary data and calls into C++.

~~**Note:** If we want to merge this, we should remember to check Node.js version support for `v8::Uint8Array`.~~ Outdated.