### PR TITLE
Close ThreadRegistry which would stop registered threads at C++ addon exit

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -110,6 +110,7 @@
 							"media-server/src/http.cpp",
 							"media-server/src/avcdescriptor.cpp",
 							"media-server/src/utf8.cpp",
+							"media-server/src/ThreadRegistry.cpp",
 							"media-server/src/DependencyDescriptorLayerSelector.cpp",
 							"media-server/src/rtp/DependencyDescriptor.cpp",
 							"media-server/src/rtp/LayerInfo.cpp",

--- a/src/MediaServer.i
+++ b/src/MediaServer.i
@@ -1,5 +1,7 @@
 %{
 
+#include "../media-server/include/ThreadRegistry.h"
+
 bool MakeCallback(const std::shared_ptr<Persistent<v8::Object>>& persistent, const char* name, int argc = 0, v8::Local<v8::Value>* argv = nullptr)
 {
 	Nan::HandleScope scope;
@@ -186,3 +188,7 @@ public:
 	static bool SetAffinity(int cpu);
 	static bool SetThreadName(const std::string& name);
 };
+
+%init %{ 
+	std::atexit(ThreadRegistry::Close);
+%}


### PR DESCRIPTION
This is to ensure threads exits after C++ environment exits.