### PR TITLE
add / fix JSDoc annotations

### DIFF
--- a/lib/ActiveSpeakerDetector.js
+++ b/lib/ActiveSpeakerDetector.js
@@ -1,9 +1,17 @@
+const IncomingStreamTrack = require("./IncomingStreamTrack");
 const Native		= require("./Native");
 const SharedPointer	= require("./SharedPointer");
 const Emitter		= require("medooze-event-emitter");
 
 /**
+ * @typedef {Object} ActiveSpeakerDetectorEvents
+ * @property {(track: IncomingStreamTrack) => void} activespeakerchanged New active speaker detected event (`track` is the track that has been activated)
+ * @property {() => void} stopped
+ */
+
+/**
  * ActiveSpeakerDetector accumulate received voice activity and fires an event when it changes
+ * @extends {Emitter<ActiveSpeakerDetectorEvents>}
  */
 class ActiveSpeakerDetector extends Emitter
 {
@@ -19,11 +27,11 @@ class ActiveSpeakerDetector extends Emitter
 		
 		//List of the tracks associated to the speakers
 		this.maxId  = 1;
-		this.ids    = new WeakMap();
-		this.tracks = new Map();
+		this.ids    = /** @type {WeakMap<IncomingStreamTrack, number>} */ (new WeakMap());
+		this.tracks = /** @type {Map<number, IncomingStreamTrack>} */ (new Map());
 		
 		//Listen for speaker changes		
-		this.onactivespeakerchanged = (id) => {
+		this.onactivespeakerchanged = (/** @type {number} */ id) => {
 			//Get track
 			const track = this.tracks.get(id);
 			//Prevent race condition
@@ -36,7 +44,7 @@ class ActiveSpeakerDetector extends Emitter
 		this.detector = new Native.ActiveSpeakerDetectorFacade(this);
 		
 		//The listener for attached tracks end event
-		this.onTrackStopped = (track) => {
+		this.onTrackStopped = (/** @type {IncomingStreamTrack} */ track) => {
 			//Remove track
 			this.removeSpeaker(track);
 		};
@@ -112,7 +120,7 @@ class ActiveSpeakerDetector extends Emitter
 	
 	/**
 	 * Remove track from speaker detection
-	 * @param {IncomingStreamTrakc} track
+	 * @param {IncomingStreamTrack} track
 	 */
 	removeSpeaker(track) 
 	{
@@ -165,6 +173,7 @@ class ActiveSpeakerDetector extends Emitter
 		super.stop();
 		
 		//Remove native reference, so destructor is called on GC
+		//@ts-expect-error
 		this.detector = null;
 	}
 	

--- a/lib/ActiveSpeakerMultiplexer.js
+++ b/lib/ActiveSpeakerMultiplexer.js
@@ -1,8 +1,27 @@
 const Native	= require("./Native");
 const Emitter	= require("medooze-event-emitter");
+const IncomingStreamTrack = require("./IncomingStreamTrack");
+const OutgoingStreamTrack = require("./OutgoingStreamTrack");
+const Transponder = require("./Transponder");
+const OutgoingStream = require("./OutgoingStream");
+
+/**
+ * @typedef {Object} Multiplex
+ * @property {number} multiplexId
+ * @property {OutgoingStreamTrack} outgoingTrack
+ * @property {Transponder} transponder
+ */
+
+/**
+ * @typedef {Object} ActiveSpeakerMultiplexerEvents
+ * @property {() => void} stopped
+ * @property {(incomingStreamTrack: IncomingStreamTrack, outgoingStreamTrack: OutgoingStreamTrack) => void} activespeakerchanged New active speaker detected (`incomingStreamTrack` is track that has been voice activated, `outgoingStreamTrack` is track that has been multiplexed into)
+ * @property {(outgoingStreamTrack: OutgoingStreamTrack) => void} noactivespeaker Active speaker removed (`outgoingStreamTrack` is track with no active speaker)
+ */
 
 /**
  * ActiveSpeakerMultiplexer multiplex multiple incoming audio tracks into fewer outgoing tracks based on voice activity.
+ * @extends {Emitter<ActiveSpeakerMultiplexerEvents>}
  */
 class ActiveSpeakerMultiplexer extends Emitter
 {
@@ -11,19 +30,24 @@ class ActiveSpeakerMultiplexer extends Emitter
 	 * @hideconstructor
 	 * private constructor
 	 */
-	constructor(timeService,streamOrTracks)
+	constructor(
+		/** @type {Native.TimeService} */ timeService,
+		/** @type {OutgoingStream | OutgoingStreamTrack[]} */ streamOrTracks)
 	{
 		//Init emitter
 		super();
 		
 		//List of the tracks associated to the speakers
 		this.maxId	= 1;
-		this.ids	= new WeakMap();
-		this.speakers	= new Map();
-		this.multiplex  = new Map();
+		this.ids	= /** @type {WeakMap<IncomingStreamTrack, number>} */ (new WeakMap());
+		this.speakers	= /** @type {Map<Number, IncomingStreamTrack>} */ (new Map());
+		this.multiplex  = /** @type {Map<Number, Multiplex>} */ (new Map());
 		
 		//Listen for speaker changes		
-		this.onactivespeakerchanged = (speakerId,multiplexeId) => {
+		this.onactivespeakerchanged = (
+			/** @type {number} */ speakerId,
+			/** @type {number} */ multiplexeId,
+		) => {
 			//Get speaker track
 			const incomingStreamTrack	= this.speakers.get(speakerId);
 			const outgoingStreamTrack	= this.multiplex.get(multiplexeId).outgoingTrack;
@@ -32,7 +56,7 @@ class ActiveSpeakerMultiplexer extends Emitter
 				//Emit event
 				this.emit("activespeakerchanged",incomingStreamTrack,outgoingStreamTrack);
 		};
-		this.onactivespeakerremoved = (multiplexeId) => {
+		this.onactivespeakerremoved = (/** @type {number} */ multiplexeId) => {
 			//Get multiplexed track
 			const outgoingStreamTrack	= this.multiplex.get(multiplexeId).outgoingTrack;
 			//Prevent race condition
@@ -45,12 +69,12 @@ class ActiveSpeakerMultiplexer extends Emitter
 		
 		
 		//The listener for attached tracks end event
-		this.onTrackStopped = (track) => {
+		this.onTrackStopped = (/** @type {IncomingStreamTrack} */ track) => {
 			//Remove track
 			this.removeSpeaker(track);
 		};
 		//The listener for attached tracks end event
-		this.onOutgoingTrackStopped = (outgoingTrack) => {
+		this.onOutgoingTrackStopped = (/** @type {OutgoingStreamTrack} */ outgoingTrack) => {
 			//Find track from multiplex
 			for (const [multiplexId,multiplex] of this.multiplex)
 			{
@@ -71,7 +95,8 @@ class ActiveSpeakerMultiplexer extends Emitter
 		this.multiplexer = new Native.ActiveSpeakerMultiplexerFacade(timeService,this);
 
 		//Get outgoing tracks
-		const outgoingTracks = streamOrTracks.getTracks ? streamOrTracks.getTracks("audio") : streamOrTracks;
+		//@ts-expect-error
+		const outgoingTracks = /** @type {OutgoingStreamTrack[]} */ (streamOrTracks.getTracks ? streamOrTracks.getTracks("audio") : streamOrTracks);
 
 		let multiplexId = 1;
 		//For each outgoing track
@@ -246,8 +271,11 @@ class ActiveSpeakerMultiplexer extends Emitter
 		super.stop();
 		
 		//Remove native reference, so destructor is called on GC
+		//@ts-expect-error
 		this.multiplexer = null;
+		//@ts-expect-error
 		this.multiplex = null;
+		//@ts-expect-error
 		this.speakers = null;
 	}
 	

--- a/lib/EmulatedTransport.js
+++ b/lib/EmulatedTransport.js
@@ -31,7 +31,7 @@ class EmulatedTransport extends Emitter
 	 * @hideconstructor
 	 * private constructor
 	 */
-	constructor(pcap)
+	constructor(/** @type {string | Native.UDPReader} */ pcap)
 	{
 		//Init emitter
 		super();
@@ -170,6 +170,7 @@ class EmulatedTransport extends Emitter
 		super.stop();
 		
 		//Remove transport reference, so destructor is called on GC
+		//@ts-expect-error
 		this.transport = null;
 	}
 }

--- a/lib/EmulatedTransport.js
+++ b/lib/EmulatedTransport.js
@@ -56,9 +56,7 @@ class EmulatedTransport extends Emitter
 	
 	/**
 	 * Set remote RTP properties 
-	 * @param {Object|SDPInfo} rtp - Object param containing media information for audio and video
-	 * @param {MediaInfo} rtp.audio	- Audio media info
-	 * @param {MediaInfo} rtp.video	- Video media info
+	 * @param {Utils.RTPProperties | SDPInfo} rtp
 	 */
 	setRemoteProperties(rtp)
 	{

--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -3,10 +3,14 @@ const Native				= require("./Native");
 const Emitter			= require("medooze-event-emitter");
 const Transport				= require("./Transport");
 const PeerConnectionServer		= require("./PeerConnectionServer");
+const SDPManager			= require("./SDPManager");
 const SDPManagerUnified			= require("./SDPManagerUnified");
 const SDPManagerPlanB			= require("./SDPManagerPlanB");
 const IncomingStream			= require("./IncomingStream");
 const IncomingStreamTrackMirrored	= require("./IncomingStreamTrackMirrored");
+const IncomingStreamTrack		= require("./IncomingStreamTrack");
+const OutgoingStream			= require("./OutgoingStream");
+const OutgoingStreamTrack		= require("./OutgoingStreamTrack");
 const ActiveSpeakerMultiplexer		= require("./ActiveSpeakerMultiplexer");
 	
 const SemanticSDP	= require("semantic-sdp");
@@ -22,6 +26,9 @@ const {
 } = require("semantic-sdp");
 
 const assertUnreachable = (/** @type {never} */ x) => { throw new Error('assertion failed') };
+
+//@ts-expect-error
+const parseInt = /** @type {(x: number) => number} */ (global.parseInt);
 
 /**
  * An endpoint represent an UDP server socket.
@@ -315,7 +322,7 @@ class Endpoint extends Emitter
 	
 	/**
 	 * Create new active speaker multiplexer for given outgoing tracks
-	 * @param {OutgoingStream|Array.OutgoingStreamTrack} streamOrTracks - Outgoing stream or outgoing stream track array to be multiplexed
+	 * @param {OutgoingStream|OutgoingStreamTrack[]} streamOrTracks - Outgoing stream or outgoing stream track array to be multiplexed
 	 * @returns {ActiveSpeakerMultiplexer}
 	 */
 	createActiveSpeakerMultiplexer(streamOrTracks)
@@ -427,7 +434,7 @@ class Endpoint extends Emitter
 	
 	/**
 	 * Create new SDP manager, this object will manage the SDP O/A for you and produce a suitable trasnport.
-	 * @param {String} sdpSemantics - Type of sdp plan "unified-plan" or "plan-b" 
+	 * @param {"unified-plan" | "plan-b"} sdpSemantics - Type of sdp plan
 	 * @param {Object} capabilities - Capabilities objects
 	 * @returns {SDPManager}
 	 */
@@ -471,6 +478,7 @@ class Endpoint extends Emitter
 		super.stop();
 		
 		//Remove bundle reference, so destructor is called on GC
+		//@ts-expect-error
 		this.bundle = null;
 	}
 }

--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -81,7 +81,7 @@ class Endpoint extends Emitter
 	 * private constructor
 	 */
 	constructor(
-		/** @type {string} */ ip,
+		/** @type {string | string[]} */ ip,
 		packetPoolSize = 0)
 	{
 		//Init emitter
@@ -97,9 +97,9 @@ class Endpoint extends Emitter
 			//Throw errror
 			throw new Error("Could not initialize bundle for endpoint");
 		//Store all transports
-		this.transports = new Set();
+		this.transports = /** @type {Set<Transport>} */ (new Set());
 		//Create candidates 
-		this.candidates = [];
+		this.candidates = /** @type {CandidateInfo[]} */ ([]);
 		//Default
 		this.defaultSRTPProtectionProfiles = "";
 		//Create candidates
@@ -115,9 +115,9 @@ class Endpoint extends Emitter
 
 		//Mirrored streams and tracks
 		this.mirrored = {
-			streams : new WeakMap(),
-			tracks	: new WeakMap(),
-			mirrors : new Set()
+			streams : /** @type {WeakMap<IncomingStream, IncomingStream>} */ (new WeakMap()),
+			tracks	: /** @type {WeakMap<IncomingStreamTrack, IncomingStreamTrackMirrored>} */ (new WeakMap()),
+			mirrors : /** @type {Set<IncomingStream>} */ (new Set()),
 		};
 	}
 	

--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -31,9 +31,47 @@ const assertUnreachable = (/** @type {never} */ x) => { throw new Error('asserti
 const parseInt = /** @type {(x: number) => number} */ (global.parseInt);
 
 /**
+ * @typedef {Object} CreateTransportOptions Dictionary with transport properties
+ * @property {boolean} [disableSTUNKeepAlive] Disable ICE/STUN keep alives, required for server to server transports
+ * @property {String} [srtpProtectionProfiles] Colon delimited list of SRTP protection profile names
+ * @property {boolean} [overrideBWE] Override BWE reported by REMB
+ * @property {boolean} [disableREMB] Disable REMB BWE calculation.
+ * @property {boolean} [prefferDTLSSetupActive] Preffer setting local DTLS setup to 'active' if remote is 'actpass'.
+ */
+
+/**
+ * @typedef {Object} PeerInfo
+ * @property {SemanticSDP.ICEInfo | SemanticSDP.ICEInfoPlain} ice ICE info, containing the username and password
+ * @property {SemanticSDP.DTLSInfo | SemanticSDP.DTLSInfoPlain} dtls DTLS info
+ * @property {(SemanticSDP.CandidateInfo | SemanticSDP.CandidateInfoPlain)[]} [candidates] ICE candidates list (for local info, it's not really used at all)
+ */
+
+/**
+ * @typedef {Object} ParsedPeerInfo
+ * @property {SemanticSDP.ICEInfo} ice
+ * @property {SemanticSDP.DTLSInfo} dtls
+ * @property {SemanticSDP.CandidateInfo[]} candidates
+ */
+
+/**
+ * @typedef {Object} RawTxOptions
+ * @property {string} interfaceName    (required) name of interface to send on
+ * @property {boolean} [skipQdisc]    whether to skip the traffic shaping (qdisc) on the interface
+ * @property {number} [sndBuf]    AF_PACKET socket send queue
+ */
+
+/** @typedef {Native.RTPBundleTransport & { rawTxInterface?: number }} NativeBundle */
+
+/**
+ * @typedef {Object} EndpointEvents
+ * @property {(self: Endpoint) => void} stopped
+ */
+
+/**
  * An endpoint represent an UDP server socket.
  * The endpoint will process STUN requests in order to be able to associate the remote ip:port with the registered transport and forward any further data comming from that transport.
  * Being a server it is ICE-lite.
+ * @extends {Emitter<EndpointEvents>}
  */
 class Endpoint extends Emitter
 {
@@ -42,7 +80,9 @@ class Endpoint extends Emitter
 	 * @hideconstructor
 	 * private constructor
 	 */
-	constructor(ip, packetPoolSize = 0)
+	constructor(
+		/** @type {string} */ ip,
+		packetPoolSize = 0)
 	{
 		//Init emitter
 		super();
@@ -50,6 +90,7 @@ class Endpoint extends Emitter
 		//Store ip address of the endpoint
 		this.ips = Array.isArray(ip) ? ip : [ip];
 		//Create native endpoint
+		/** @type {NativeBundle} */
 		this.bundle = new Native.RTPBundleTransport(packetPoolSize);
 		//Start it
 		if (!this.bundle.Init())
@@ -93,7 +134,7 @@ class Endpoint extends Emitter
 
 	/** 
 	 * setDefaultSRTProtectionProfiles
-	 * @param {String} profiles - Colon delimited list of SRTP protection profile names
+	 * @param {String} srtpProtectionProfiles - Colon delimited list of SRTP protection profile names
 	 */
 	 setDefaultSRTProtectionProfiles(srtpProtectionProfiles)
 	 {
@@ -102,6 +143,8 @@ class Endpoint extends Emitter
 
 	/**
 	 * [EXPERIMENTAL] See TypeScript typings for usage.
+	 *
+	 * @param {false | RawTxOptions} options Options for raw TX. Pass false to disable.
 	 */
 	async setRawTx(options)
 	{
@@ -167,20 +210,9 @@ class Endpoint extends Emitter
 	
 	/**
 	 * Create a new transport object and register it with the remote ICE username and password
-	 * @param {Object|SDPInfo}  remoteInfo	- Remote ICE and DTLS properties
-	 * @param {Object|ICEInfo}  remoteInfo.ice	- Remote ICE info, containing the username and password.
-	 * @param {Object|DTLSInfo} remoteInfo.dtls	- Remote DTLS info
-	 * @param {Array.CandidateInfo|Array.Object} remoteInfo.candidates - Remote ICE candidate info
-	 * @param {Object}   localInfo		- Local ICE and DTLS properties (optional)
-	 * @param {ICEInfo}  localInfo.ice		- Local ICE info, containing the username and password. Local ICE candidates list is not really used at all.
-	 * @param {DTLSInfo} localInfo.dtls		- Local DTLS info
-	 * @param {Array.CandidateInfo} localInfo.candidates - Local candidate info
-	 * @param {Object} options		- Dictionary with transport properties
-	 * @param {boolean} options.disableSTUNKeepAlive - Disable ICE/STUN keep alives, required for server to server transports
-	 * @param {String} options.srtpProtectionProfiles - Colon delimited list of SRTP protection profile names
-	 * @param {boolean} options.overrideBWE - Override BWE reported by REMB
-	 * @param {boolean} options.disableREMB - Disable REMB BWE calculation.
-	 * @param {boolean} options.prefferDTLSSetupActive - Preffer setting local DTLS setup to 'active' if remote is 'actpass'.
+	 * @param {SemanticSDP.SDPInfo | PeerInfo} remoteInfo Remote ICE and DTLS properties
+	 * @param {SemanticSDP.SDPInfo | PeerInfo} [localInfo] Local ICE and DTLS properties
+	 * @param {CreateTransportOptions} [options]
 	 * @returns {Transport}	New transport object
 	 */
 	createTransport(remoteInfo, localInfo, options)
@@ -273,7 +305,7 @@ class Endpoint extends Emitter
 	}
 	/**
 	 * Get local ICE candidates for this endpoint. It will be shared by all the transport associated to this endpoint.
-	 * @returns {Array.CandidateInfo}
+	 * @returns {Array<CandidateInfo>}
 	 */
 	getLocalCandidates() 
 	{
@@ -294,7 +326,7 @@ class Endpoint extends Emitter
 	/**
 	 * Helper that creates an offer from capabilities
 	 * It generates a random ICE username and password and gets endpoint fingerprint
-	 * @param {Object} capabilities - Media capabilities as required by SDPInfo.create
+	 * @param {SemanticSDP.Capabilities} [capabilities] - Media capabilities as required by SDPInfo.create
 	 * @returns {SDPInfo} - SDP offer
 	 */
 	createOffer(capabilities)
@@ -310,8 +342,8 @@ class Endpoint extends Emitter
 	
 	/**
 	 * Create new peer connection server to manage remote peer connection clients
-	 * @param {TransactionManager} tm
-	 * @param {Object} capabilities - Same as SDPInfo.answer capabilites
+	 * @param {any} tm
+	 * @param {SemanticSDP.Capabilities} capabilities - Same as SDPInfo.answer capabilites
 	 * @returns {PeerConnectionServer}
 	 */
 	createPeerConnectionServer(tm,capabilities)
@@ -435,7 +467,7 @@ class Endpoint extends Emitter
 	/**
 	 * Create new SDP manager, this object will manage the SDP O/A for you and produce a suitable trasnport.
 	 * @param {"unified-plan" | "plan-b"} sdpSemantics - Type of sdp plan
-	 * @param {Object} capabilities - Capabilities objects
+	 * @param {SemanticSDP.Capabilities} capabilities - Capabilities objects
 	 * @returns {SDPManager}
 	 */
 	createSDPManager(sdpSemantics,capabilities)

--- a/lib/IncomingStream.js
+++ b/lib/IncomingStream.js
@@ -15,8 +15,20 @@ const {
 	TrackInfo,
 } = require("semantic-sdp");
 
+/** @typedef {string} SourceId */
+
+/**
+ * @typedef {Object} IncomingStreamEvents
+ * @property {(self: IncomingStream, stats: ReturnType<IncomingStream['getStats']>) => void} stopped
+ * @property {(self: IncomingStream) => void} attached
+ * @property {(self: IncomingStream) => void} detached
+ * @property {(muted: boolean) => void} muted
+ * @property {(self: IncomingStream, track: IncomingStreamTrack) => void} track IncomingStreamTrack added to stream
+ */
+
 /**
  * The incoming streams represent the recived media stream from a remote peer.
+ * @extends {Emitter<IncomingStreamEvents>}
  */
 class IncomingStream extends Emitter
 {
@@ -25,7 +37,10 @@ class IncomingStream extends Emitter
 	 * @hideconstructor
 	 * private constructor
 	 */
-	constructor(transport,receiver,info)
+	constructor(
+		/** @type {Native.DTLSICETransport} */ transport,
+		/** @type {SharedPointer.Proxy<Native.RTPReceiverShared>} */ receiver,
+		/** @type {StreamInfo | SemanticSDP.StreamInfoPlain} */ info)
 	{
 		//Init emitter
 		super();
@@ -45,7 +60,7 @@ class IncomingStream extends Emitter
 		this.counter = 0;
 		
 		//Store sources
-		this.tracks = new Map();
+		this.tracks = /** @type {Map<string, IncomingStreamTrack>} */ (new Map());
 		
 		try {
 			//For each tracks
@@ -90,13 +105,13 @@ class IncomingStream extends Emitter
 	/**
 	 * Get statistics for all tracks in the stream
 	 * 
-	 * See IncomingStreamTrack.getStats for information about the stats returned by each track.
+	 * See {@link IncomingStreamTrack.getStats} for information about the stats returned by each track.
 	 * 
-	 * @returns {Map<String>,Object} Map with stats by trackId
+	 * @returns {{ [trackId: string]: IncomingStreamTrack.TrackStats }}
 	 */
 	getStats() 
 	{
-		const stats = {};
+		const stats = /** @type {{ [trackId: string]: IncomingStreamTrack.TrackStats }} */ ({});
 		
 		//for each track
 		for (let track of this.tracks.values())
@@ -109,9 +124,9 @@ class IncomingStream extends Emitter
 	/**
 	 * Get statistics for all tracks in the stream
 	 * 
-	 * See IncomingStreamTrack.getStats for information about the stats returned by each track.
+	 * See {@link IncomingStreamTrack.getStats} for information about the stats returned by each track.
 	 * 
-	 * @returns Promise<{Map<String>,Object}> Map with stats by trackId
+	 * @returns {Promise<{ [trackId: string]: IncomingStreamTrack.TrackStats }>}
 	 */
 	async getStatsAsync() 
 	{
@@ -155,7 +170,7 @@ class IncomingStream extends Emitter
 	/**
 	 * Get track by id
 	 * @param {String} trackId	- The track id
-	 * @returns {IncomingStreamTrack}	- requested track or null
+	 * @returns {IncomingStreamTrack | undefined}	- requested track or null
 	 */
 	getTrack(trackId) 
 	{
@@ -165,7 +180,7 @@ class IncomingStream extends Emitter
 	
 	/**
 	 * Get all the tracks
-	 * @param {SemanticSDP.MediaType} type	- The media type (Optional)
+	 * @param {"audio" | "video"} [type]	- The media type (Optional)
 	 * @returns {Array<IncomingStreamTrack>}	- Array of tracks
 	 */
 	getTracks(type) 
@@ -214,9 +229,9 @@ class IncomingStream extends Emitter
 	
 	
 	/**
-	 * Adds an incoming stream track created using the Transponder.createIncomingStreamTrack to this stream
+	 * Adds an incoming stream track created using {@link Transponder.createIncomingStreamTrack} to this stream
 	 *  
-	 * @param {IncomingStreamTrack} track
+	 * @param {IncomingStreamTrack} incomingStreamTrack
 	 */
 	addTrack(incomingStreamTrack)
 	{
@@ -284,10 +299,10 @@ class IncomingStream extends Emitter
 			throw new Error("Duplicated track id");
 		
 		//Is it audio or video
-		const type	 = trackInfo.getMedia()==="audio" ? 0 : 1;
+		const type	 = /** @type {Native.MediaFrameType} */ (trackInfo.getMedia()==="audio" ? 0 : 1);
 
 		//The map of incoming sources
-		const sources	 = {};
+		const sources	 = /** @type {IncomingStreamTrack.NativeSourceMap} */ ({});
 
 		//Get encodings
 		const encodings	 = trackInfo.getEncodings();
@@ -502,6 +517,7 @@ class IncomingStream extends Emitter
 		super.stop();
 		
 		//Remove transport reference, so destructor is called on GC
+		//@ts-expect-error
 		this.transport = null;
 	}
 }

--- a/lib/IncomingStream.js
+++ b/lib/IncomingStream.js
@@ -132,7 +132,7 @@ class IncomingStream extends Emitter
 		return this.muted;
 	}
 	
-	/*
+	/**
 	 * Mute/Unmute this stream and all the tracks in it
 	 * @param {boolean} muting - if we want to mute or unmute
 	 */
@@ -165,7 +165,7 @@ class IncomingStream extends Emitter
 	
 	/**
 	 * Get all the tracks
-	 * @param {String} type	- The media type (Optional)
+	 * @param {SemanticSDP.MediaType} type	- The media type (Optional)
 	 * @returns {Array<IncomingStreamTrack>}	- Array of tracks
 	 */
 	getTracks(type) 
@@ -213,7 +213,7 @@ class IncomingStream extends Emitter
 	}
 	
 	
-	/*
+	/**
 	 * Adds an incoming stream track created using the Transponder.createIncomingStreamTrack to this stream
 	 *  
 	 * @param {IncomingStreamTrack} track

--- a/lib/IncomingStreamTrack.js
+++ b/lib/IncomingStreamTrack.js
@@ -18,23 +18,30 @@ const {
 
 /**
  * @typedef {Object} LayerStats Information about each spatial/temporal layer (if present)
+ * @property {boolean} [active]
  * @property {number} simulcastIdx
  * @property {number} spatialLayerId Spatial layer id
  * @property {number} temporalLayerId Temporatl layer id
  * @property {number} [totalBytes] total rtp received bytes for this layer
  * @property {number} [numPackets] number of rtp packets received for this layer
  * @property {number} bitrate average bitrate received during last second for this layer
+ * @property {number} [targetBitrate] signaled target bitrate on the VideoLayersAllocation header
+ * @property {number} [targetWidth] signaled target width on the VideoLayersAllocation header
+ * @property {number} [targetHeight] signaled target height on the VideoLayersAllocation header
+ * @property {number} [targetFps] signaled target fps on the VideoLayersAllocation header
  */
 
 /**
  * @typedef {Object} MediaStats stats for each media stream
  * @property {number} [lostPackets] total lost packkets
  * @property {number} [lostPacketsDelta] total lost/out of order packets during last second
+ * @property {number} [lostPacketsMaxGap] max total consecutive packets lost during last second
+ * @property {number} [lostPacketsGapCount] number of packet loss bursts during last second
  * @property {number} [dropPackets] droppted packets by media server
- * @property {number} numFrames number of rtp packets received
- * @property {number} numFramesDelta number of rtp packets received during last seconds
+ * @property {number} numFrames number of frames received
+ * @property {number} numFramesDelta number of frames received during last second
  * @property {number} numPackets number of rtp packets received
- * @property {number} numPacketsDelta number of rtp packets received during last seconds
+ * @property {number} numPacketsDelta number of rtp packets received during last second
  * @property {number} [numRTCPPackets] number of rtcp packsets received
  * @property {number} totalBytes total rtp received bytes
  * @property {number} [totalRTCPBytes] total rtp received bytes
@@ -43,8 +50,15 @@ const {
  * @property {number} bitrate average bitrate received during last second in bps
  * @property {number} [skew] difference between NTP timestamp and RTP timestamps at sender (from RTCP SR)
  * @property {number} [drift] ratio between RTP timestamps and the NTP timestamp and  at sender (from RTCP SR)
- * @property {number} [clockRate] RTP clockrate
- * @property {LayerStats[]} layers Information about each spatial/temporal layer (if present)
+ * @property {number} [clockrate] RTP clockrate
+ * @property {number} [frameDelay] Average frame delay during the last second
+ * @property {number} [frameDelayMax] Max frame delay during the last second
+ * @property {number} [frameCaptureDelay] Average bewtween local reception time and sender capture one (Absolute capture time must be negotiated)
+ * @property {number} [frameCaptureDelayMax] Max bewtween local reception time and sender capture one (Absolute capture time must be negotiated)
+ * @property {number} [width] video width
+ * @property {number} [height] video height
+ * @property {LayerStats[]} layers Information about each spatial/temporal layer (if present).
+ * @property {LayerStats[]} [individual] Information about each individual layer
  */
 
 /**
@@ -55,27 +69,30 @@ const {
  */
 
 /**
- * @typedef {Object} EncodingStats stats for each encoding (media, rtx sources (if used))
+ * @typedef {Object} EncodingStats stats for each encoding (media and rtx sources (if used))
  *
  * @property {number} timestamp When this stats was generated (in order to save workload, stats are cached for 200ms)
  * @property {PacketWaitTime} waitTime 
  * @property {MediaStats} media Stats for the media stream
- * @property {{}} rtx Stats for the rtx retransmission stream
+ * @property {MediaStats} [rtx] Stats for the rtx retransmission stream
  * 
  * @property {number} [rtt] Round Trip Time in ms
  * @property {number} bitrate Bitrate for media stream only in bps
- * @property {number} total Accumulated bitrate for rtx, media streams in bps
- * @property {number} [remb] Estimated avialable bitrate for receving (only avaailable if not using tranport wide cc)
+ * @property {number} total Accumulated bitrate for media and rtx streams in bps
+ * @property {number} [remb] Estimated available bitrate for receving (only available if not using transport wide cc)
  * @property {number} simulcastIdx Simulcast layer index based on bitrate received (-1 if it is inactive).
- * @property {number} [lostPackets] Accumulated lost packets for rtx, media strems
  * @property {number} [lostPacketsRatio] Lost packets ratio
+ * @property {number} [width] video width
+ * @property {number} [height] video height
  *
- * Info accumulated for `rtx`, `media` streams:
+ * Info accumulated for `media` and `rtx` streams:
  *
  * @property {number} numFrames
  * @property {number} numFramesDelta
  * @property {number} numPackets
  * @property {number} numPacketsDelta
+ * @property {number} [lostPackets]
+ * @property {number} [lostPacketsDelta]
  */
 
 /** @typedef {{ [encodingId: string]: EncodingStats }} TrackStats providing the info for each source */
@@ -94,6 +111,8 @@ const {
  * @property {number} simulcastIdx
  * @property {number} bitrate
  * @property {LayerStats[]} layers
+ * @property {number} [width]
+ * @property {number} [height]
  */
 
 /**
@@ -397,7 +416,8 @@ function getActiveLayersFromStats(/** @type {TrackStats} */ stats)
  * @typedef {Object} IncomingStreamTrackEvents
  * @property {(self: IncomingStreamTrack) => void} attached
  * @property {(self: IncomingStreamTrack) => void} detached
- * @property {(self: IncomingStreamTrack) => void} stopped
+ * @property {(muted: boolean) => void} muted
+ * @property {(self: IncomingStreamTrack, stats: TrackStats) => void} stopped
  */
 
 /**

--- a/lib/IncomingStreamTrack.js
+++ b/lib/IncomingStreamTrack.js
@@ -16,7 +16,95 @@ const {
 	SourceGroupInfo,
 } = require("semantic-sdp");
 
-function getEncodingStats(encoding)
+/**
+ * @typedef {Object} LayerStats Information about each spatial/temporal layer (if present)
+ * @property {number} simulcastIdx
+ * @property {number} spatialLayerId Spatial layer id
+ * @property {number} temporalLayerId Temporatl layer id
+ * @property {number} [totalBytes] total rtp received bytes for this layer
+ * @property {number} [numPackets] number of rtp packets received for this layer
+ * @property {number} bitrate average bitrate received during last second for this layer
+ */
+
+/**
+ * @typedef {Object} MediaStats stats for each media stream
+ * @property {number} [lostPackets] total lost packkets
+ * @property {number} [lostPacketsDelta] total lost/out of order packets during last second
+ * @property {number} [dropPackets] droppted packets by media server
+ * @property {number} numFrames number of rtp packets received
+ * @property {number} numFramesDelta number of rtp packets received during last seconds
+ * @property {number} numPackets number of rtp packets received
+ * @property {number} numPacketsDelta number of rtp packets received during last seconds
+ * @property {number} [numRTCPPackets] number of rtcp packsets received
+ * @property {number} totalBytes total rtp received bytes
+ * @property {number} [totalRTCPBytes] total rtp received bytes
+ * @property {number} [totalPLIs] total PLIs sent
+ * @property {number} [totalNACKs] total NACk packets sent
+ * @property {number} bitrate average bitrate received during last second in bps
+ * @property {number} [skew] difference between NTP timestamp and RTP timestamps at sender (from RTCP SR)
+ * @property {number} [drift] ratio between RTP timestamps and the NTP timestamp and  at sender (from RTCP SR)
+ * @property {number} [clockRate] RTP clockrate
+ * @property {LayerStats[]} layers Information about each spatial/temporal layer (if present)
+ */
+
+/**
+ * @typedef PacketWaitTime packet waiting times in rtp buffer before delivering them
+ * @property {number} min
+ * @property {number} max
+ * @property {number} avg
+ */
+
+/**
+ * @typedef {Object} EncodingStats stats for each encoding (media, rtx sources (if used))
+ *
+ * @property {number} timestamp When this stats was generated (in order to save workload, stats are cached for 200ms)
+ * @property {PacketWaitTime} waitTime 
+ * @property {MediaStats} media Stats for the media stream
+ * @property {{}} rtx Stats for the rtx retransmission stream
+ * 
+ * @property {number} [rtt] Round Trip Time in ms
+ * @property {number} bitrate Bitrate for media stream only in bps
+ * @property {number} total Accumulated bitrate for rtx, media streams in bps
+ * @property {number} [remb] Estimated avialable bitrate for receving (only avaailable if not using tranport wide cc)
+ * @property {number} simulcastIdx Simulcast layer index based on bitrate received (-1 if it is inactive).
+ * @property {number} [lostPackets] Accumulated lost packets for rtx, media strems
+ * @property {number} [lostPacketsRatio] Lost packets ratio
+ *
+ * Info accumulated for `rtx`, `media` streams:
+ *
+ * @property {number} numFrames
+ * @property {number} numFramesDelta
+ * @property {number} numPackets
+ * @property {number} numPacketsDelta
+ */
+
+/** @typedef {{ [encodingId: string]: EncodingStats }} TrackStats providing the info for each source */
+
+/**
+ * @typedef {Object} Encoding
+ * @property {string} id
+ * @property {SharedPointer.Proxy<Native.RTPIncomingSourceGroupShared>} source
+ * @property {SharedPointer.Proxy<Native.RTPReceiverShared>} receiver
+ * @property {SharedPointer.Proxy<Native.RTPIncomingMediaStreamDepacketizerShared>} depacketizer
+ */
+
+/**
+ * @typedef {Object} ActiveEncodingInfo
+ * @property {string} id
+ * @property {number} simulcastIdx
+ * @property {number} bitrate
+ * @property {LayerStats[]} layers
+ */
+
+/**
+ * @typedef {Object} ActiveLayersInfo Active layers object containing an array of active and inactive encodings and an array of all available layer info
+ * @property {ActiveEncodingInfo[]} active
+ * @property {Array<LayerStats & { encodingId: string }>} layers
+ * @property {{ id: string }[]} inactive
+ */
+
+/** @returns {EncodingStats} */
+function getEncodingStats(/** @type {Encoding} */ encoding)
 {
 	//Get stats from sources
 	const mediaStats = getStatsFromIncomingSource(encoding.source.media);
@@ -59,8 +147,10 @@ function getEncodingStats(encoding)
 	return encodingStats;
 }
 
-function getStatsFromIncomingSource(source) 
+/** @returns {MediaStats} */
+function getStatsFromIncomingSource(/** @type {Native.RTPIncomingSource} */ source) 
 {
+	/** @type {MediaStats} */
 	const stats = {
 		numFrames		: source.numFrames,
 		numFramesDelta		: source.numFramesDelta,
@@ -98,7 +188,7 @@ function getStatsFromIncomingSource(source)
 	const layers = source.layers();
 
 	//Not aggregated stats
-	const individual = stats.individual = [];
+	const individual = stats.individual = /** @type {LayerStats[]} */ ([]);
 
 	//Check if it has layer stats
 	for (let i=0; i<layers.size(); ++i)
@@ -106,6 +196,7 @@ function getStatsFromIncomingSource(source)
 		//Get layer
 		const layer = layers.get(i);
 		
+		/** @type {LayerStats} */
 		const curated = {
 			spatialLayerId  : layer.spatialLayerId,
 			temporalLayerId : layer.temporalLayerId,
@@ -137,6 +228,7 @@ function getStatsFromIncomingSource(source)
 		if (!source.aggregatedLayers)
 		{
 			//Create empty stat
+			/** @type {LayerStats} */
 			const aggregated = {
 				spatialLayerId: individual[i].spatialLayerId,
 				temporalLayerId: individual[i].temporalLayerId,
@@ -183,7 +275,7 @@ function getStatsFromIncomingSource(source)
 	return stats;
 }
 
-function updateStatsSimulcastIndex(stats)
+function updateStatsSimulcastIndex(/** @type {TrackStats} */ stats)
 {
 	//Set simulcast index
 	let simulcastIdx = 0;
@@ -204,11 +296,12 @@ function updateStatsSimulcastIndex(stats)
 }
 
 
-function getActiveLayersFromStats(stats)
+/** @returns {ActiveLayersInfo} */
+function getActiveLayersFromStats(/** @type {TrackStats} */ stats)
 {
-	const active	= [];
-	const inactive  = [];
-	const all	= [];
+	const active	= /** @type {ActiveLayersInfo['active']} */ ([]);
+	const inactive  = /** @type {ActiveLayersInfo['inactive']} */ ([]);
+	const all	= /** @type {ActiveLayersInfo['layers']} */ ([]);
 
 	//For all encodings
 	for (const id in stats)
@@ -225,6 +318,7 @@ function getActiveLayersFromStats(stats)
 		}
 			
 		//Append to encodings
+		/** @type {ActiveEncodingInfo} */
 		const encoding = {
 			id		: id,
 			simulcastIdx	: stats[id].simulcastIdx,
@@ -298,8 +392,17 @@ function getActiveLayersFromStats(stats)
 		layers          : all.sort((a, b) => b.bitrate - a.bitrate)
 	};
 }
+
+/**
+ * @typedef {Object} IncomingStreamTrackEvents
+ * @property {(self: IncomingStreamTrack) => void} attached
+ * @property {(self: IncomingStreamTrack) => void} detached
+ * @property {(self: IncomingStreamTrack) => void} stopped
+ */
+
 /**
  * Audio or Video track of a remote media stream
+ * @extends {Emitter<IncomingStreamTrackEvents>}
  */
 class IncomingStreamTrack extends Emitter
 {
@@ -308,7 +411,13 @@ class IncomingStreamTrack extends Emitter
 	 * @hideconstructor
 	 * private constructor
 	 */
-	constructor(media,id,mediaId,timeService,receiver,sources)
+	constructor(
+		/** @type {"audio" | "video"} */ media,
+		/** @type {string} */ id,
+		/** @type {string} */ mediaId,
+		/** @type {Native.TimeService} */ timeService,
+		/** @type {SharedPointer.Proxy<Native.RTPReceiverShared>} */ receiver,
+		/** @type {{ [id: string]: SharedPointer.Proxy<Native.RTPIncomingSourceGroupShared> }} */ sources)
 	{
 		//Init emitter
 		super();
@@ -324,13 +433,13 @@ class IncomingStreamTrack extends Emitter
 		this.counter	= 0;
 
 		//Cached stats
-		this.stats = {};
+		this.stats = /** @type {TrackStats} */ ({});
 	
 		//Create info
 		this.trackInfo = new TrackInfo(media, id);
 		
 		//Create source map
-		this.encodings = new Map();
+		this.encodings = /** @type {Map<string, Encoding>} */ (new Map());
 
 		//Get number of encodings
 		const num = Object.keys(sources).length;
@@ -394,58 +503,7 @@ class IncomingStreamTrack extends Emitter
 	
 	/**
 	 * Get stats for all encodings 
-	 * 
-	 * For each encoding you will get stats for media and rtx sources (if used):
-	 *  - media    : Stats for the media stream
-	 *  - rtx      : Stats for the rtx retransmission stream
-	 *  - rtt      : Round Trip Time in ms
-	 *  - waitTime : "min","max" and "avg" packet waiting times in rtp buffer before delivering them
-	 *  - bitrate  : Bitrate for media stream only in bps
-	 *  - total    : Accumulated bitrate for media and rtx streams in bps
-	 *  - remb     : Estimated avialable bitrate for receving (only avaailable if not using tranport wide cc)
-	 *  - timestamp: When this stats was generated, in order to save workload, stats are cached for 200ms
-	 *  - simulcastIdx	: Simulcast layer index based on bitrate received (-1 if it is inactive).
-	 *  - lostPackets	: Accumulated lost packets for media and rtx strems
-	 *  - numPackets	: Accumulated packets for media and rtx strems
-	 *  - lostPacketsRatio	: Lost packets ratio
-	 * 
-	 * The stats objects will provide the following info for each source
-	 *  - numFrames		: total recevied frames
-	 *  - numFramesDelta	: recevied frames during last second
-	 *  - lostPackets	: total lost packkets
-	 *  - lostPacketsDelta	: Lost/out of order packets during last second
-	 *  - lostPacketsMaxGap	: max total consecutieve packets lossed during last second
-	 *  - lostPacketsGapCount : number of packet looses bursts during last second
-	 *  - dropPackets       : droppted packets by media server
-	 *  - numPackets	: number of rtp packets received
-	 *  - numPacketsDelta	: number of rtp packets received during last seconds
-	 *  - numRTCPPackets	: number of rtcp packsets received
-	 *  - totalBytes	: total rtp received bytes
-	 *  - totalRTCPBytes	: total rtp received bytes
-	 *  - totalPLIs		: total PLIs sent
-	 *  - totalNACKs	: total NACk packets sent
-	 *  - bitrate		: average bitrate received during last second in bps
-	 *  - skew		: difference between NTP timestamp and RTP timestamps at sender (from RTCP SR)
-	 *  - drift		: ratio between RTP timestamps and the NTP timestamp and  at sender (from RTCP SR)
-	 *  - clockRate		: RTP clockrate
-	 *  - frameDelay	: Average frame delay during the last second
-	 *  - frameDelayMax	: Max frame delay during the last second
-	 *  - frameCaptureDelay		: Average bewtween local reception time and sender capture one (Absolute capture time must be negotiated)
-	 *  - frameCaptureDelayMax	: Max bewtween local reception time and sender capture one (Absolute capture time must be negotiated)
-	 *  - width		: video width
-	 *  - height		: video height
-	 *  - layers		: Information about each spatial/temporal layer (if present)
-	 *    * spatialLayerId  : Spatial layer id
-	 *    * temporalLayerId : Temporatl layer id
-	 *    * totalBytes	: total rtp received bytes for this layer
-	 *    * numPackets	: number of rtp packets received for this layer
-	 *    * bitrate		: average bitrate received during last second for this layer
-	 *    * targetBitrate	: Signaled target bitrate on the VideoLayersAllocation header
-	 *    * targetWidth	: Signaled target width on the VideoLayersAllocation header
-	 *    *	targetHeight	: Signaled target height on the VideoLayersAllocation header
-	 *    *	targetFps	: Signaled target fps on the VideoLayersAllocation header
-	 *  
-	 * @returns Promise<{Map<String,Object>}> Promise resolving to a map with stats by encodingId
+	 * @returns {Promise<TrackStats>}
 	 */
 	async getStatsAsync()
 	{
@@ -477,54 +535,7 @@ class IncomingStreamTrack extends Emitter
 
 	/**
 	 * Get stats for all encodings 
-	 * 
-	 * For each encoding you will get stats for media and rtx sources (if used):
-	 *  - media    : Stats for the media stream
-	 *  - rtx      : Stats for the rtx retransmission stream
-	 *  - rtt      : Round Trip Time in ms
-	 *  - waitTime : "min","max" and "avg" packet waiting times in rtp buffer before delivering them
-	 *  - bitrate  : Bitrate for media stream only in bps
-	 *  - total    : Accumulated bitrate for media and rtx streams in bps
-	 *  - remb     : Estimated avialable bitrate for receving (only avaailable if not using tranport wide cc)
-	 *  - timestamp: When this stats was generated, in order to save workload, stats are cached for 200ms
-	 *  - simulcastIdx	: Simulcast layer index based on bitrate received (-1 if it is inactive).
-	 *  - lostPackets	: Accumulated lost packets for media and rtx strems
-	 *  - numPackets	: Accumulated packets for media and rtx strems
-	 *  - lostPacketsRatio	: Lost packets ratio
-	 * 
-	 * The stats objects will provide the following info for each source
-	 *  - numFrames		: total recevied frames
-	 *  - numFramesDelta	: recevied frames during last second
-	 *  - lostPackets	: total lost packkets
-	 *  - lostPacketsDelta	: Lost/out of order packets during last second
-	 *  - lostPacketsMaxGap	: max total consecutieve packets lossed during last second
-	 *  - lostPacketsGapCount : number of packet looses bursts during last second
-	 *  - dropPackets       : droppted packets by media server
-	 *  - numPackets	: number of rtp packets received
-	 *  - numPacketsDelta	: number of rtp packets received during last seconds
-	 *  - numRTCPPackets	: number of rtcp packsets received
-	 *  - totalBytes	: total rtp received bytes
-	 *  - totalRTCPBytes	: total rtp received bytes
-	 *  - totalPLIs		: total PLIs sent
-	 *  - totalNACKs	: total NACk packets sent
-	 *  - bitrate		: average bitrate received during last second in bps
-	 *  - skew		: difference between NTP timestamp and RTP timestamps at sender (from RTCP SR)
-	 *  - drift		: ratio between RTP timestamps and the NTP timestamp and  at sender (from RTCP SR)
-	 *  - clockRate		: RTP clockrate
-	 *  - frameDelay	: Average frame delay during the last second
-	 *  - frameDelayMax	: Max frame delay during the last second
-	 *  - frameCaptureDelay		: Average bewtween local reception time and sender capture one (Absolute capture time must be negotiated)
-	 *  - frameCaptureDelayMax	: Max bewtween local reception time and sender capture one (Absolute capture time must be negotiated)
-	 *  - width		: video width
-	 *  - height		: video height
-	 *  - layers		: Information about each spatial/temporal layer (if present)
-	 *    * spatialLayerId  : Spatial layer id
-	 *    * temporalLayerId : Temporatl layer id
-	 *    * totalBytes	: total rtp received bytes for this layer
-	 *    * numPackets	: number of rtp packets received for this layer
-	 *    * bitrate		: average bitrate received during last second for this layer
-	 *  
-	 * @returns {Map<String,Object>} Map with stats by encodingId
+	 * @returns {TrackStats}
 	 */
 	getStats()
 	{
@@ -554,7 +565,7 @@ class IncomingStreamTrack extends Emitter
 	
 	/**
 	 * Get active encodings and layers ordered by bitrate
-	 * @returns {Object} Active layers object containing an array of active and inactive encodings and an array of all available layer info
+	 * @returns {ActiveLayersInfo} Active layers object containing an array of active and inactive encodings and an array of all available layer info
 	 */
 	getActiveLayers()
 	{
@@ -567,7 +578,7 @@ class IncomingStreamTrack extends Emitter
 
 	/**
 	 * Get active encodings and layers ordered by bitrate
-	 * @returns Promise<{Object}> Active layers object containing an array of active and inactive encodings and an array of all available layer info
+	 * @returns {Promise<ActiveLayersInfo>} Active layers object containing an array of active and inactive encodings and an array of all available layer info
 	 */
 	async getActiveLayersAsync()
 	{
@@ -596,7 +607,6 @@ class IncomingStreamTrack extends Emitter
 	
 	/**
 	 * Get track info object
-	 * @returns {TrackInfo} Track info
 	 */
 	getTrackInfo()
 	{
@@ -604,11 +614,10 @@ class IncomingStreamTrack extends Emitter
 	}
 	/**
 	 * Return ssrcs associated to this track
-	 * @returns {Object}
 	 */
 	getSSRCs()
 	{
-		const ssrcs = {};
+		const ssrcs = /** @type {{ [encodingId: string]: { media: number, rtx: number } }} */ ({});
 		
 		//For each source
 		for (let encoding of this.encodings.values())
@@ -623,7 +632,7 @@ class IncomingStreamTrack extends Emitter
 	
 	/**
 	* Get track media type
-	* @returns {String} "audio"|"video" 
+	* @returns {"audio"|"video"}
 	*/
 	getMedia()
 	{
@@ -633,7 +642,7 @@ class IncomingStreamTrack extends Emitter
 	/**
 	 * Get all track encodings
 	 * Internal use, you'd beter know what you are doing before calling this method
-	 * @returns {Array<Object>} - encodings 
+	 * @returns {Array<Encoding>} - encodings 
 	 **/
 	getEncodings()
 	{
@@ -644,7 +653,7 @@ class IncomingStreamTrack extends Emitter
 	 * Get encoding by id
 	 * Internal use, you'd beter know what you are doing before calling this method
 	 * @param {String} encodingId	- encoding Id,
-	 * @returns {Object}		- encoding 
+	 * @returns {Encoding | undefined}
 	 **/
 	getEncoding(encodingId)
 	{
@@ -654,7 +663,7 @@ class IncomingStreamTrack extends Emitter
 	/**
 	 * Get default encoding
 	 * Internal use, you'd beter know what you are doing before calling this method
-	 * @returns {Object}		- encoding 
+	 * @returns {Encoding}
 	 **/
 	getDefaultEncoding()
 	{
@@ -706,7 +715,7 @@ class IncomingStreamTrack extends Emitter
 		return this.muted;
 	}
 
-	/*
+	/**
 	 * Mute/Unmute track
 	 * @param {boolean} muting - if we want to mute or unmute
 	 */
@@ -775,7 +784,7 @@ class IncomingStreamTrack extends Emitter
 	
 	/**
 	 * Get out of band h264 parameters from this track
-	 * @returns {Boolean} 
+	 * @returns {String | undefined} 
 	 */
 	getH264ParameterSets()
 	{
@@ -839,9 +848,11 @@ class IncomingStreamTrack extends Emitter
 		
 		//remove encodings
 		this.encodings.clear();
+		//@ts-expect-error
 		this.depacketizer = null;
 		
 		//Remove transport reference, so destructor is called on GC
+		//@ts-expect-error
 		this.receiver = null;
 	}
 }

--- a/lib/IncomingStreamTrack.js
+++ b/lib/IncomingStreamTrack.js
@@ -423,6 +423,8 @@ function getActiveLayersFromStats(/** @type {TrackStats} */ stats)
  * @property {(self: Self, stats?: TrackStats) => void} stopped
  */
 
+/** @typedef {{ [id: string]: SharedPointer.Proxy<Native.RTPIncomingSourceGroupShared> }} NativeSourceMap */
+
 /**
  * Audio or Video track of a remote media stream
  * @extends {Emitter<IncomingStreamTrackEvents<IncomingStreamTrack, Encoding>>}
@@ -440,7 +442,7 @@ class IncomingStreamTrack extends Emitter
 		/** @type {string} */ mediaId,
 		/** @type {Native.TimeService} */ timeService,
 		/** @type {SharedPointer.Proxy<Native.RTPReceiverShared>} */ receiver,
-		/** @type {{ [id: string]: SharedPointer.Proxy<Native.RTPIncomingSourceGroupShared> }} */ sources)
+		/** @type {NativeSourceMap} */ sources)
 	{
 		//Init emitter
 		super();
@@ -473,11 +475,8 @@ class IncomingStreamTrack extends Emitter
 			this.depacketizer = SharedPointer(new Native.SimulcastMediaFrameListenerShared(timeService, 1, num));
 		
 		//For each source
-		for (let id of Object.keys(sources))
+		for (let [id, source] of Object.entries(sources))
 		{
-			//Get source
-			const source = sources[id];
-
 			//The encoding
 			const encoding = {
 				id		: id,
@@ -637,6 +636,7 @@ class IncomingStreamTrack extends Emitter
 	}
 	/**
 	 * Return ssrcs associated to this track
+	 * @returns {{ [encodingId: string]: import("./Transport").SSRCs }}
 	 */
 	getSSRCs()
 	{

--- a/lib/IncomingStreamTrack.js
+++ b/lib/IncomingStreamTrack.js
@@ -413,16 +413,19 @@ function getActiveLayersFromStats(/** @type {TrackStats} */ stats)
 }
 
 /**
+ * @template Self
+ * @template Encoding
  * @typedef {Object} IncomingStreamTrackEvents
- * @property {(self: IncomingStreamTrack) => void} attached
- * @property {(self: IncomingStreamTrack) => void} detached
+ * @property {(self: Self, encoding: Encoding) => void} encoding New encoding (right now, this is only used by {@link IncomingStreamTrackMirrored})
+ * @property {(self: Self) => void} attached
+ * @property {(self: Self) => void} detached
  * @property {(muted: boolean) => void} muted
- * @property {(self: IncomingStreamTrack, stats: TrackStats) => void} stopped
+ * @property {(self: Self, stats?: TrackStats) => void} stopped
  */
 
 /**
  * Audio or Video track of a remote media stream
- * @extends {Emitter<IncomingStreamTrackEvents>}
+ * @extends {Emitter<IncomingStreamTrackEvents<IncomingStreamTrack, Encoding>>}
  */
 class IncomingStreamTrack extends Emitter
 {

--- a/lib/IncomingStreamTrackMirrored.js
+++ b/lib/IncomingStreamTrackMirrored.js
@@ -2,6 +2,7 @@ const Native		= require("./Native");
 const SharedPointer	= require("./SharedPointer");
 const Emitter		= require("medooze-event-emitter");
 const LayerInfo		= require("./LayerInfo");
+const IncomingStreamTrack = require("./IncomingStreamTrack");
 const SemanticSDP	= require("semantic-sdp");
 const {
 	SDPInfo,
@@ -17,7 +18,20 @@ const {
 } = require("semantic-sdp");
 
 /**
+ * @typedef {Object} Encoding
+ * this type is like {@link IncomingStreamTrack.Encoding} except that `source` is renamed to a new `mirror`
+ * property, and then the `source` property is instead backed by a `RTPIncomingMediaStreamMultiplexer`.
+ *
+ * @property {string} id
+ * @property {SharedPointer.Proxy<Native.RTPIncomingSourceGroupShared>} mirror
+ * @property {SharedPointer.Proxy<Native.RTPIncomingMediaStreamMultiplexerShared>} source
+ * @property {SharedPointer.Proxy<Native.RTPReceiverShared>} receiver
+ * @property {SharedPointer.Proxy<Native.RTPIncomingMediaStreamDepacketizerShared>} depacketizer
+ */
+
+/**
  * Mirror incoming stream from another endpoint. Used to avoid inter-thread synchronization when attaching multiple output streams.
+ * @extends {Emitter<IncomingStreamTrack.IncomingStreamTrackEvents<IncomingStreamTrackMirrored, Encoding>>}
  */
 class IncomingStreamTrackMirrored extends Emitter
 {
@@ -26,7 +40,9 @@ class IncomingStreamTrackMirrored extends Emitter
 	 * @hideconstructor
 	 * private constructor
 	 */
-	constructor(incomingStreamTrack,timeService)
+	constructor(
+		/** @type {IncomingStreamTrack} */ incomingStreamTrack,
+		/** @type {Native.TimeService} */ timeService)
 	{
 		//Init emitter
 		super();
@@ -40,10 +56,10 @@ class IncomingStreamTrackMirrored extends Emitter
 		this.counter	= 0;
 	
 		//Create source map
-		this.encodings = new Map();
+		this.encodings = /** @type {Map<string, Encoding>} */ (new Map());
 
 		//Internal function for adding a new mirrored encoding to the track
-		const addEncoding = (encoding) => {
+		const addEncoding = (/** @type {IncomingStreamTrack.Encoding} */ encoding) => {
 			//Check if we had already an encoding for it (i.e. in case of SimulcastAdapter adding and removing a trac)
 			const old = this.encodings.get(encoding.id);
 
@@ -94,8 +110,6 @@ class IncomingStreamTrackMirrored extends Emitter
 	
 	/**
 	 * Get stats for all encodings from the original track
-	 * 
-	 * @returns {Map<String,Object>} Map with stats by encodingId
 	 */
 	getStats()
 	{
@@ -104,8 +118,6 @@ class IncomingStreamTrackMirrored extends Emitter
 	
 	/**
 	 * Get stats for all encodings from the original track
-	 * 
-	 * @returns {Map<String,Object>} Map with stats by encodingId
 	 */
 	async getStatsAsync()
 	{
@@ -114,7 +126,6 @@ class IncomingStreamTrackMirrored extends Emitter
 
 	/**
 	 * Get active encodings and layers ordered by bitrate of the original track
-	 * @returns {Object} Active layers object containing an array of active and inactive encodings and an array of all available layer info
 	 */
 	getActiveLayers()
 	{
@@ -123,7 +134,6 @@ class IncomingStreamTrackMirrored extends Emitter
 
 	/**
 	 * Get active encodings and layers ordered by bitrate of the original track
-	 * @returns {Object} Active layers object containing an array of active and inactive encodings and an array of all available layer info
 	 */
 	async getActiveLayersAsync()
 	{
@@ -157,7 +167,6 @@ class IncomingStreamTrackMirrored extends Emitter
 	}
 	/**
 	 * Return ssrcs associated to this track
-	 * @returns {Object}
 	 */
 	getSSRCs()
 	{
@@ -166,7 +175,7 @@ class IncomingStreamTrackMirrored extends Emitter
 	
 	/**
 	* Get track media type
-	* @returns {String} "audio"|"video" 
+	* @returns {"audio"|"video"}
 	*/
 	getMedia()
 	{
@@ -176,7 +185,7 @@ class IncomingStreamTrackMirrored extends Emitter
 	/**
 	 * Get all track encodings
 	 * Internal use, you'd beter know what you are doing before calling this method
-	 * @returns {Array<Object>} - encodings 
+	 * @returns {Array<Encoding>} - encodings 
 	 **/
 	getEncodings()
 	{
@@ -187,7 +196,7 @@ class IncomingStreamTrackMirrored extends Emitter
 	 * Get encoding by id
 	 * Internal use, you'd beter know what you are doing before calling this method
 	 * @param {String} encodingId	- encoding Id,
-	 * @returns {Object}		- encoding 
+	 * @returns {Encoding | undefined}
 	 **/
 	getEncoding(encodingId)
 	{
@@ -197,7 +206,7 @@ class IncomingStreamTrackMirrored extends Emitter
 	/**
 	 * Get default encoding
 	 * Internal use, you'd beter know what you are doing before calling this method
-	 * @returns {Object}		- encoding 
+	 * @returns {Encoding}
 	 **/
 	getDefaultEncoding()
 	{
@@ -272,7 +281,7 @@ class IncomingStreamTrackMirrored extends Emitter
 		return this.muted;
 	}
 
-	/*
+	/**
 	 * Mute/Unmute track
 	 * @param {boolean} muting - if we want to mute or unmute
 	 */
@@ -327,7 +336,9 @@ class IncomingStreamTrackMirrored extends Emitter
 		super.stop();
 		
 		//Remove track reference
+		//@ts-expect-error
 		this.track = null;
+		//@ts-expect-error
 		this.receiver = null;
 	}
 }

--- a/lib/IncomingStreamTrackReader.js
+++ b/lib/IncomingStreamTrackReader.js
@@ -2,7 +2,24 @@ const Native		= require("./Native");
 const Emitter		= require("medooze-event-emitter");
 const Refresher		= require("./Refresher")
 const SharedPointer	= require("./SharedPointer");
+const IncomingStreamTrack = require("./IncomingStreamTrack");
 
+/** @typedef {"Audio" | "Video" | "Text" | "Unknown"} FrameType */
+
+/**
+ * @typedef {Object} Frame
+ * @property {FrameType} type
+ * @property {string} codec
+ * @property {Uint8Array} buffer
+ */
+
+/**
+ * @typedef {Object} IncomingStreamTrackReaderEvents
+ * @property {(self: IncomingStreamTrackReader) => void} stopped
+ * @property {(frame: Frame, self: IncomingStreamTrackReader) => void} frame
+ */
+
+/** @extends {Emitter<IncomingStreamTrackReaderEvents>} */
 class IncomingStreamTrackReader extends Emitter
 {
 	/**
@@ -10,7 +27,10 @@ class IncomingStreamTrackReader extends Emitter
 	 * @hideconstructor
 	 * private constructor
 	 */
-	constructor(intraOnly,minPeriod,ondemand)
+	constructor(
+		/** @type {boolean} */ intraOnly,
+		/** @type {number} */ minPeriod,
+		/** @type {boolean} */ ondemand)
 	{
 		//Init emitter
 		super();
@@ -39,7 +59,11 @@ class IncomingStreamTrackReader extends Emitter
 			this.detach();
 		};
 		//Frame listener
-		this.onframe = (buffer,type,codec) => {
+		this.onframe = (
+			/** @type {Uint8Array} */ buffer,
+			/** @type {FrameType} */ type,
+			/** @type {string} */ codec,
+		) => {
 			this.emit("frame", {buffer,type,codec}, this);
 			//Reset refresher interval
 			this.refresher?.restart(this.minPeriod);
@@ -69,7 +93,7 @@ class IncomingStreamTrackReader extends Emitter
 		this.attached = null;
 	}
 	
-	attachTo(track)
+	attachTo(/** @type {IncomingStreamTrack} */ track)
 	{
 		//Detach first
 		this.detach();
@@ -110,6 +134,7 @@ class IncomingStreamTrackReader extends Emitter
 		super.stop();
 		
 		//Remove native refs
+		//@ts-expect-error
 		this.reader = null;
 	}
 }

--- a/lib/IncomingStreamTrackSimulcastAdapter.js
+++ b/lib/IncomingStreamTrackSimulcastAdapter.js
@@ -2,6 +2,7 @@ const Native		= require("./Native");
 const Emitter		= require("medooze-event-emitter");
 const LayerInfo		= require("./LayerInfo");
 const SharedPointer	= require("./SharedPointer");
+const IncomingStreamTrack = require("./IncomingStreamTrack");
 const SemanticSDP	= require("semantic-sdp");
 const {
 	SDPInfo,
@@ -15,6 +16,8 @@ const {
 	TrackEncodingInfo,
 	SourceGroupInfo,
 } = require("semantic-sdp");
+
+/** @typedef {IncomingStreamTrack.Encoding} Encoding */
 
 function getActiveLayersFromStats(stats)
 {
@@ -122,6 +125,7 @@ function updateStatsSimulcastIndex(stats)
 
 /**
  * Bundle multiple video track as if they were a single simulcast video track
+ * @extends {Emitter<IncomingStreamTrack.IncomingStreamTrackEvents<IncomingStreamTrackSimulcastAdapter, Encoding>>}
  */
 class IncomingStreamTrackSimulcastAdapter extends Emitter
 {
@@ -130,14 +134,17 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 	 * @hideconstructor
 	 * private constructor
 	 */
-	constructor(id,mediaId,timeService)
+	constructor(
+		/** @type {string} */ id,
+		/** @type {string} */ mediaId,
+		/** @type {Native.TimeService} */ timeService)
 	{
 		//Init emitter
 		super();
 
 		//Store track id
 		this.id = id;
-		this.media = "video";
+		this.media = /** @type {const} */ ("video");
 		this.mediaId = mediaId;
 		//Not muted
 		this.muted = false;
@@ -149,14 +156,14 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 		this.trackInfo = new TrackInfo(this.media, id);
 	
 		//Create source maps
-		this.encodings = new Map();
-		this.encodingPerTrack = new Map();
+		this.encodings = /** @type {Map<string, Encoding>} */ (new Map());
+		this.encodingPerTrack = /** @type {Map<IncomingStreamTrack, Map<string, Encoding>>} */ (new Map());
 
 		//Create a simulcast frame listerner
 		this.depacketizer = SharedPointer(new Native.SimulcastMediaFrameListenerShared(timeService, 1, 0));
 		
 		//On stopped listener
-		this.onstopped = (incomingStreamTrack) => {
+		this.onstopped = (/** @type {IncomingStreamTrack} */ incomingStreamTrack) => {
 			//Remove track
 			this.removeTrack(incomingStreamTrack);
 		};
@@ -174,7 +181,7 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 			//Error
 			throw Error("Cannot add track, it is already present");
 
-		const encodings = new Map();
+		const encodings = /** @type {Map<string, Encoding>} */ (new Map());
 
 		//Check incoming track mute state
 		if (incomingStreamTrack.isMuted() != this.muted)
@@ -275,12 +282,11 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 
 	/**
 	 * Get stats for all encodings from the original track
-	 * 
-	 * @returns {Map<String,Object>} Map with stats by encodingId
+	 * @returns {IncomingStreamTrack.TrackStats}
 	 */
 	getStats()
 	{
-		const stats = {};
+		const stats = /** @type {IncomingStreamTrack.TrackStats} */ ({});
 		
 		//For each track
 		for (const [track,encodings] of this.encodingPerTrack)
@@ -306,12 +312,11 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 
 	/**
 	 * Get stats for all encodings from the original track
-	 * 
-	 * @returns Promise<{Map<String,Object>}> Map with stats by encodingId
+	 * @returns {Promise<IncomingStreamTrack.TrackStats>}
 	 */
 	async getStatsAsync()
 	{
-		const stats = {};
+		const stats = /** @type {IncomingStreamTrack.TrackStats} */ ({});
 		
 		//For each track
 		for (const [track,encodings] of this.encodingPerTrack)
@@ -337,7 +342,6 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 	
 	/**
 	 * Get active encodings and layers ordered by bitrate of the original track
-	 * @returns {Object} Active layers object containing an array of active and inactive encodings and an array of all available layer info
 	 */
 	getActiveLayers()
 	{
@@ -350,7 +354,6 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 
 	/**
 	 * Get active encodings and layers ordered by bitrate of the original track
-	 * @returns {Object} Active layers object containing an array of active and inactive encodings and an array of all available layer info
 	 */
 	async getActiveLayersAsync()
 	{
@@ -379,7 +382,6 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 	
 	/**
 	 * Get track info object
-	 * @returns {TrackInfo} Track info
 	 */
 	getTrackInfo()
 	{
@@ -398,7 +400,6 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 	
 	/**
 	* Get track media type
-	* @returns {String} "audio"|"video" 
 	*/
 	getMedia()
 	{
@@ -408,7 +409,7 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 	/**
 	 * Get all track encodings
 	 * Internal use, you'd beter know what you are doing before calling this method
-	 * @returns {Array<Object>} - encodings 
+	 * @returns {Array<Encoding>} - encodings 
 	 **/
 	getEncodings()
 	{
@@ -419,7 +420,7 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 	 * Get encoding by id
 	 * Internal use, you'd beter know what you are doing before calling this method
 	 * @param {String} encodingId	- encoding Id,
-	 * @returns {Object}		- encoding 
+	 * @returns {Encoding | undefined}
 	 **/
 	getEncoding(encodingId)
 	{
@@ -429,7 +430,7 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 	/**
 	 * Get default encoding
 	 * Internal use, you'd beter know what you are doing before calling this method
-	 * @returns {Object}		- encoding 
+	 * @returns {Encoding}
 	 **/
 	getDefaultEncoding()
 	{
@@ -445,7 +446,7 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 		return this.muted;
 	}
 
-	/*
+	/**
 	 * Mute/Unmute track
 	 * @param {boolean} muting - if we want to mute or unmute
 	 */

--- a/lib/MediaServer.js
+++ b/lib/MediaServer.js
@@ -24,6 +24,9 @@ const {
 	Setup,
 } = require("semantic-sdp");
 
+//@ts-expect-error
+const parseInt = /** @type {(x: number) => number} */ (global.parseInt);
+
 //INitialize DTLS
 Native.MediaServer.Initialize();
 
@@ -105,8 +108,8 @@ MediaServer.enableDebug = function(flag)
 /**
  * Set UDP port range for encpoints
  * @memberof MediaServer
- * @param {Integer} minPort - Min UDP port
- * @param {Integer} maxPort - Max UDP port [Optional]
+ * @param {Number} minPort - Min UDP port
+ * @param {Number} maxPort - Max UDP port [Optional]
  */
 MediaServer.setPortRange = function(minPort,maxPort)
 {
@@ -117,7 +120,7 @@ MediaServer.setPortRange = function(minPort,maxPort)
 /**
  * Set node uv loop cpu affinity
  * @memberof MediaServer
- * @param {Integer} cpu - CPU core number
+ * @param {Number} cpu - CPU core number
  * @returns {boolean} true if operation was successful
  */
 MediaServer.setAffinity = function(cpu)
@@ -153,11 +156,15 @@ MediaServer.enableUltraDebug = function(flag)
 };
 
 /**
+ * @typedef {Object} EndpointParams Endpoint creation parameters
+ * @property {number} packetPoolSize Packet pool size
+ */
+
+/**
  * Create a new endpoint object
  * @memberof MediaServer
  * @param {String} ip				- External IP address of server, to be used when announcing the local ICE candidate
- * @param {Object} params			- Creation parameters
- * @param {Number} params.packetPoolSize	- Packet pool size
+ * @param {EndpointParams} [params]
  * @returns {Endpoint} The new created endpoing
  */
 MediaServer.createEndpoint = function(ip, params)
@@ -180,7 +187,7 @@ MediaServer.createEndpoint = function(ip, params)
 /**
 * Helper that creates an offer from capabilities
 * It generates a random ICE username and password and gets media server dtls fingerprint
-* @param {Object} capabilities - Media capabilities as required by SDPInfo.create
+* @param {SemanticSDP.Capabilities} [capabilities] - Media capabilities as required by SDPInfo.create
 * @returns {SDPInfo} - SDP offer
 */
 MediaServer.createOffer = function(capabilities)
@@ -198,11 +205,7 @@ MediaServer.createOffer = function(capabilities)
 * Create a new MP4 recorder
 * @memberof MediaServer
 * @param {String} filename - Path and filename of the recorded mp4 file
-* @param {Object} params - Recording parameters (Optional)
-* @param {Number} params.refresh - Periodically refresh an intra on all video tracks (in ms)
-* @param {Boolean} params.waitForIntra - Wait until first video iframe is received to start recording media
-* @param {Number} params.timeShift - Buffer time in ms. Recording must be splicity started with flush() call
-* @param {Boolean} params.disableHints - Disable recording hint tracks. Note that this file won't be playable with the Player object;
+* @param {Recorder.RecorderParams} [params]
 * @returns {Recorder}
 */
 MediaServer.createRecorder = function(filename,params)
@@ -246,7 +249,7 @@ MediaServer.createActiveSpeakerDetector = function()
 
 /**
  * Create a new stream refresher
- * @param {type} period - Intra refresh period
+ * @param {number} period - Intra refresh period
 */
 MediaServer.createRefresher = function(period)
 {
@@ -256,8 +259,8 @@ MediaServer.createRefresher = function(period)
 
 /**
  * Create a new incoming track reader
- * @param {type} intraOnly - Intra frames only
- * @param {type} minPeriod - Minimum period between frames
+ * @param {boolean} intraOnly - Intra frames only
+ * @param {number} minPeriod - Minimum period between frames
 */
 MediaServer.createIncomingStreamTrackReader = function(intraOnly, minPeriod)
 {
@@ -269,7 +272,7 @@ MediaServer.createIncomingStreamTrackReader = function(intraOnly, minPeriod)
 
 /**
  * Create a new emulated transport from pcap file
- * @param {String} filename - PCAP filename and path
+ * @param {String} pcap - PCAP filename and path
 */
 MediaServer.createEmulatedTransport = function(pcap)
 {
@@ -289,7 +292,9 @@ MediaServer.createEmulatedTransport = function(pcap)
 	return endpoint;
 };
 
-MediaServer.createIncomingStreamTrackSimulcastAdapter = function(trackId, mediaId)
+MediaServer.createIncomingStreamTrackSimulcastAdapter = function(
+	/** @type {string} */ trackId,
+	/** @type {string} */ mediaId)
 {
 	//Create one event loop for this
 	const loop = new Native.EventLoop();
@@ -303,7 +308,10 @@ MediaServer.createIncomingStreamTrackSimulcastAdapter = function(trackId, mediaI
 	return incomingStreamTrack;
 }
 
-MediaServer.createIncomingStreamSimulcastAdapter = function(streamId, trackId, mediaId)
+MediaServer.createIncomingStreamSimulcastAdapter = function(
+	/** @type {string} */ streamId,
+	/** @type {string} */ trackId,
+	/** @type {string} */ mediaId)
 {
 	//Create transport-less stream
 	const incomingStream = new IncomingStream(null,null,{id: streamId,tracks:[]});
@@ -317,7 +325,7 @@ MediaServer.createIncomingStreamSimulcastAdapter = function(streamId, trackId, m
 
 /**
  * Get the default media server capabilities for each supported media type
- * @returns {Object} Object containing the capabilities by media ("audio","video")
+ * @returns {SemanticSDP.Capabilities} Object containing the capabilities by media ("audio","video")
  */
 MediaServer.getDefaultCapabilities = function()
 {

--- a/lib/MediaServer.js
+++ b/lib/MediaServer.js
@@ -163,7 +163,7 @@ MediaServer.enableUltraDebug = function(flag)
 /**
  * Create a new endpoint object
  * @memberof MediaServer
- * @param {String} ip				- External IP address of server, to be used when announcing the local ICE candidate
+ * @param {string | string[]} ip				- External IP address of server, to be used when announcing the local ICE candidate
  * @param {EndpointParams} [params]
  * @returns {Endpoint} The new created endpoing
  */

--- a/lib/Native.js
+++ b/lib/Native.js
@@ -5,10 +5,11 @@ const SharedPointer = require("./SharedPointer");
 try 
 {
 	//We try first to load it via dlopen on Node 9
+	//@ts-expect-error
 	process.dlopen(module,path.resolve(path.dirname(module.filename), "../build/Release/medooze-media-server.node"), os.constants.dlopen.RTLD_NOW);// | os.constants.dlopen.RTLD_DEEPBIND);
 } catch (e) {
 	//old one
-	module.exports = require("../build/Release/medooze-media-server");
+	module.exports = require(/** @type {any} */ ("../build/Release/medooze-media-server"));
 }
 
 SharedPointer.wrapNativeModule(module);

--- a/lib/NetworkUtils.js
+++ b/lib/NetworkUtils.js
@@ -1,16 +1,15 @@
-//@ts-check
 const util = require('util');
 const dgram = require('dgram');
 const events = require('events');
 
-const be32 = (x) => {
+const be32 = (/** @type {number} */ x) => {
 	if (x !== (x >>> 0))
 		throw Error(`not a u32: ${x}`)
 	const r = Buffer.alloc(4);
 	r.writeUInt32BE(x);
 	return r;
 }
-const be16 = (x) => {
+const be16 = (/** @type {number} */ x) => {
 	if (x !== (x & 0xFFFF))
 		throw Error(`not a u16: ${x}`)
 	const r = Buffer.alloc(2);
@@ -21,7 +20,7 @@ const be16 = (x) => {
 
 // Utilities to manipulate MAC addresses
 
-function formatMac(mac)
+function formatMac(/** @type {Uint8Array} */ mac)
 {
 	if (!(mac instanceof Uint8Array && mac.length === 6))
 		throw TypeError('invalid MAC address');
@@ -31,15 +30,15 @@ function formatMac(mac)
 
 // Utilities to manipulate IPv4 addresses
 
-const verifyRange = (x, max) => {
-	x = parseInt(x);
+const verifyRange = (/** @type {string} */ xStr, /** @type {number} */ max) => {
+	const x = parseInt(xStr);
 	if (x > max)
 		throw Error(`${x} exceeds ${max}`);
 	return x;
 }
 
 /** parse a dot-separated IPv4 into a normalized address as u32be */
-function parseIPv4(ip)
+function parseIPv4(/** @type {string} */ ip)
 {
 	if (!/^(?:\d+\.){3}\d+$/.test(ip))
 		throw Error(`invalid IPv4: ${ip}`);
@@ -47,18 +46,20 @@ function parseIPv4(ip)
 	return rawAddr.readUInt32BE();
 }
 
+/** @typedef {readonly [number, number]} CIDR */
+
 /** parse a CIDR into a normalized [address as u32be, prefix length] tuple */
-function parseCIDR(cidr)
+function parseCIDR(/** @type {string} */ cidr)
 {
 	if (!/^[^/]+\/\d+$/.exec(cidr))
 		throw Error(`invalid CIDR: ${cidr}`);
 	const [addr, prefix] = cidr.split('/');
-	return [parseIPv4(addr), verifyRange(prefix, 32)];
+	return /** @type {const} */ ([parseIPv4(addr), verifyRange(prefix, 32)]);
 }
 
-const cidrMask = (n) => (~0) << (32 - n);
-const isInsidePrefix = (prefix, addr) => prefix[1] <= addr[1] && !((prefix[0] ^ addr[0]) & cidrMask(prefix[1]));
-const isReservedAddress = (addr) => reservedRanges.some(range => isInsidePrefix(range, addr));
+const cidrMask = (/** @type {number} */ n) => (~0) << (32 - n);
+const isInsidePrefix = (/** @type {CIDR} */ prefix, /** @type {CIDR} */ addr) => prefix[1] <= addr[1] && !((prefix[0] ^ addr[0]) & cidrMask(prefix[1]));
+const isReservedAddress = (/** @type {CIDR} */ addr) => reservedRanges.some(range => isInsidePrefix(range, addr));
 
 const reservedRanges = [
 	'0.0.0.0/8',
@@ -110,7 +111,7 @@ async function withSocket(callback)
 	}
 }
 
-const getInterfaceRawConfig = (name, rtNetlink) => withSocket(async rtNetlink => {
+const getInterfaceRawConfig = (/** @type {string} */ name) => withSocket(async rtNetlink => {
 	// fetch link
 	const [ link ] = await rtNetlink.getLink({}, { ifname: name })
 		.catch(error => { throw Error(`failed to find interface ${name}: ${error}`) });
@@ -126,7 +127,7 @@ const getInterfaceRawConfig = (name, rtNetlink) => withSocket(async rtNetlink =>
 		.filter(route => route.data.dstLen === 0 && route.attrs.gateway);
 	const defaultRoute = routes.length ? 
 		(await collectRoutingInfoWithRoute(rtNetlink, index, routes[0], routes[0].attrs.gateway.readUInt32BE())) :
-		[ 0, '00:00:00:00:00:00' ]; // silently give an invalid value
+		/** @type {const} */ ([ 0, '00:00:00:00:00:00' ]); // silently give an invalid value
 
 	return { index, lladdr: formatMac(lladdr), defaultRoute };
 });
@@ -137,8 +138,12 @@ const IPPROTO_UDP = 17
 const extractOne = (list, name) =>
 	list.length === 1 ? list[0] : Promise.reject(`expected one ${name}, ${list.length} returned`);
 
-const collectCandidateInfo = (ip, port, ifindex) => withSocket(async rtNetlink => {
-	ip = parseIPv4(ip);
+const collectCandidateInfo = (
+	/** @type {string} */ ipStr,
+	/** @type {number} */ port,
+	/** @type {number} */ ifindex,
+) => withSocket(async rtNetlink => {
+	const ip = parseIPv4(ipStr);
 
 
 	// PART 1: perform a FIB lookup to see where Linux routes this candidate at.
@@ -178,6 +183,7 @@ const collectCandidateInfo = (ip, port, ifindex) => withSocket(async rtNetlink =
  * @param {number} ifindex Interface
  * @param {import('netlink').rt.RouteMessage} route Selected route
  * @param {number} dst Resolved next hop address for route
+ * @returns {Promise<readonly [number, string]>} selected route as a (source IP, destination MAC) tuple
  */
 const collectRoutingInfoWithRoute = async (rtNetlink, ifindex, route, dst) => {
 	const { data: { scope }, attrs: { prefsrc } } = route;

--- a/lib/NetworkUtils.js
+++ b/lib/NetworkUtils.js
@@ -111,11 +111,23 @@ async function withSocket(callback)
 	}
 }
 
+/**
+ * @typedef InterfaceRawConfig
+ * @property {number} index Interface index (ifindex)
+ * @property {string} lladdr MAC address
+ * @property {readonly [number, string]} defaultRoute
+ */
+
+/**
+ * get configuration of an interface by name
+ * @returns {Promise<InterfaceRawConfig>}
+ */
 const getInterfaceRawConfig = (/** @type {string} */ name) => withSocket(async rtNetlink => {
 	// fetch link
 	const [ link ] = await rtNetlink.getLink({}, { ifname: name })
 		.catch(error => { throw Error(`failed to find interface ${name}: ${error}`) });
-	const { data: { index, type }, attrs: { address: lladdr } } = link;
+	const { data: { index, type }, attrs: { address: lladdr } } =
+		/** @type {(typeof link) & { data: { index: number } }} */ (link);
 	if (type !== 'ETHER')
 		throw Error('not an Ethernet interface');
 	if (!lladdr)

--- a/lib/OutgoingStream.js
+++ b/lib/OutgoingStream.js
@@ -3,6 +3,7 @@ const SharedPointer		= require("./SharedPointer");
 const Emitter		= require("medooze-event-emitter");
 const SemanticSDP		= require("semantic-sdp");
 const OutgoingStreamTrack	= require("./OutgoingStreamTrack");
+const Transponder		= require("./Transponder");
 const { v4: uuidV4 }		= require("uuid");
 
 const {
@@ -16,8 +17,18 @@ const {
 	TrackInfo,
 } = require("semantic-sdp");
 
+/** @typedef {import("./Transport").CreateStreamTrackOptions & { media: "audio" | "video" }} CreateTrackOptions */
+
+/**
+ * @typedef {Object} OutgoingStreamEvents
+ * @property {(self: OutgoingStream, stats: ReturnType<OutgoingStream['getStats']>) => void} stopped
+ * @property {(track: OutgoingStreamTrack) => void} track Track was created
+ * @property {(muted: boolean) => void} muted
+ */
+
 /**
  * The incoming streams represent the media stream sent to a remote peer.
+ * @extends {Emitter<OutgoingStreamEvents>}
  */
 class OutgoingStream extends Emitter
 {
@@ -26,7 +37,10 @@ class OutgoingStream extends Emitter
 	 * @hideconstructor
 	 * private constructor
 	 */
-	constructor(transport,lfsr,info)
+	constructor(
+		/** @type {SharedPointer.Proxy<Native.DTLSICETransportShared>} */ transport,
+		/** @type {any} */ lfsr,
+		/** @type {StreamInfo | SemanticSDP.StreamInfoPlain} */ info)
 	{
 		//Init emitter
 		super();
@@ -43,7 +57,7 @@ class OutgoingStream extends Emitter
 		this.lfsr	= lfsr;
 		
 		//Store sources
-		this.tracks = new Map();
+		this.tracks = /** @type {Map<string, OutgoingStreamTrack>} */ (new Map());
 		
 		try {
 			//For each tracks
@@ -63,13 +77,13 @@ class OutgoingStream extends Emitter
 	/**
 	 * Get statistics for all tracks in the stream
 	 * 
-	 * See OutgoingStreamTrack.getStats for information about the stats returned by each track.
+	 * See {@link OutgoingStreamTrack.getStats} for information about the stats returned by each track.
 	 * 
-	 * @returns {Map<String>,Object} Map with stats by trackId
+	 * @returns {{ [trackId: string]: OutgoingStreamTrack.TrackStats }}
 	 */
 	getStats() 
 	{
-		const stats = {};
+		const stats = /** @type {{ [trackId: string]: OutgoingStreamTrack.TrackStats }} */ ({});
 		
 		//for each track
 		for (let track of this.tracks.values())
@@ -82,9 +96,9 @@ class OutgoingStream extends Emitter
 	/**
 	 * Get statistics for all tracks in the stream
 	 * 
-	 * See OutgoingStreamTrack.getStats for information about the stats returned by each track.
+	 * See {@link OutgoingStreamTrack.getStats} for information about the stats returned by each track.
 	 * 
-	 * @returns {Map<String>,Object} Map with stats by trackId
+	 * @returns {Promise<{ [trackId: string]: OutgoingStreamTrack.TrackStats }>}
 	 */
 	async getStatsAsync() 
 	{
@@ -127,14 +141,9 @@ class OutgoingStream extends Emitter
 	
 	/**
 	 * Listen media from the incoming stream and send it to the remote peer of the associated transport.
-	 * @param {IncomingStream} incomingStream - The incoming stream to listen media for
-	 * @returns {Array<Transponder>} Track transponders array
-	 * @param {Object} layers			- [Optional] Only applicable to video tracks
-	 * @param {String} layers.encodingId		- rid value of the simulcast encoding of the track (default: first encoding available)
-	 * @param {Number} layers.spatialLayerId	- The spatial layer id to send to the outgoing stream (default: max layer available)
-	 * @param {Number} layers.temporalLayerId	- The temporal layer id to send to the outgoing stream (default: max layer available)
-	 * @param {Number} layers.maxSpatialLayerId	- Max spatial layer id (default: unlimited)
-	 * @param {Number} layers.maxTemporalLayerId	- Max temporal layer id (default: unlimited)
+	 * @param {import("./IncomingStream")} incomingStream - The incoming stream to listen media for
+	 * @param {Transponder.LayerSelection} [layers]
+	 * @returns {Transponder[]} Track transponders array
 	 */
 	attachTo(incomingStream, layers)
 	{
@@ -142,7 +151,7 @@ class OutgoingStream extends Emitter
 		this.detach();
 		
 		//The transponders
-		const transponders = [];
+		const transponders = /** @type {Transponder[]} */ ([]);
 		
 		//Get all of our audio streams
 		const audio = this.getAudioTracks();
@@ -206,7 +215,7 @@ class OutgoingStream extends Emitter
 
 	/**
 	 * Get all the tracks
-	 * @param {String} type	- The media type (Optional)
+	 * @param {"audio" | "video"} [type]	- The media type (Optional)
 	 * @returns {Array<OutgoingStreamTrack>}	- Array of tracks
 	 */
 	getTracks(type) 
@@ -220,7 +229,7 @@ class OutgoingStream extends Emitter
 	/**
 	 * Get track by id
 	 * @param {String} trackId	- The track id
-	 * @returns {IncomingStreamTrack}	- requested track or null
+	 * @returns {OutgoingStreamTrack | undefined}	- requested track or null
 	 */
 	getTrack(trackId) 
 	{
@@ -265,7 +274,7 @@ class OutgoingStream extends Emitter
 	}
 	
 	/**
-	 * Adds an incoming stream track created using [[Transponder.createOutgoingStreamTrack]] to this stream
+	 * Adds an incoming stream track created using {@link Transport.createOutgoingStreamTrack} to this stream
 	 *  
 	 * @param {OutgoingStreamTrack} track
 	 */
@@ -292,20 +301,23 @@ class OutgoingStream extends Emitter
 	
 	/**
 	 * Create new track from a TrackInfo object and add it to this stream
-	 * @param {Object|TrackInfo|String} params Params plain object, StreamInfo object or media type
+	 * @param {CreateTrackOptions | TrackInfo | SemanticSDP.MediaType} params Params plain object, StreamInfo object or media type
 	 * @returns The new outgoing stream
 	 */
 	createTrack(params)
 	{
+		/** @type {string} */
 		let trackId;
 		
 		//Get media type
-		const media = params.constructor.name === "TrackInfo" ? params.getMedia() : params && params.media ? params.media : params;
+		//@ts-expect-error
+		const media = /** @type {SemanticSDP.MediaType} */ (params.constructor.name === "TrackInfo" ? params.getMedia() : params && params.media ? params.media : params);
 		
 		//Is it audio or video
-		const type  = media==="audio" ? 0 : 1;
+		const type  = /** @type {Native.MediaFrameType} */ (media==="audio" ? 0 : 1);
 
 		//Get mid
+		//@ts-expect-error
 		const mediaId = String((params.constructor.name === "TrackInfo" ? params.getMediaId() : params && params.mediaId ? params.mediaId : "") || "");
 		
 		//Create incoming track
@@ -315,7 +327,7 @@ class OutgoingStream extends Emitter
 		if (params.constructor.name === "TrackInfo")
 		{
 			//The params is the track info
-			const trackInfo = params;
+			const trackInfo = /** @type {TrackInfo} */ (params);
 			//Get trackId
 			trackId = trackInfo.getId();
 			//Set source data
@@ -328,6 +340,8 @@ class OutgoingStream extends Emitter
 			source.rtx.ssrc = FID ? FID.getSSRCs()[1] : 0;
 
 		} else {
+			params = /** @type {CreateTrackOptions} */ (params);
+
 			//Get trackId
 			trackId = params.id || uuidV4();
 			
@@ -401,6 +415,7 @@ class OutgoingStream extends Emitter
 		super.stop();
 		
 		//Remove transport reference, so destructor is called on GC
+		//@ts-expect-error
 		this.transport = null;
 	}
 };

--- a/lib/OutgoingStream.js
+++ b/lib/OutgoingStream.js
@@ -105,7 +105,7 @@ class OutgoingStream extends Emitter
 		return this.muted;
 	}
 	
-	/*
+	/**
 	 * Mute/Unmute this stream and all the tracks in it
 	 * @param {boolean} muting - if we want to mute or unmute
 	 */
@@ -132,7 +132,7 @@ class OutgoingStream extends Emitter
 	 * @param {Object} layers			- [Optional] Only applicable to video tracks
 	 * @param {String} layers.encodingId		- rid value of the simulcast encoding of the track (default: first encoding available)
 	 * @param {Number} layers.spatialLayerId	- The spatial layer id to send to the outgoing stream (default: max layer available)
-	 * @param {Number} layers.temporalLayerId	- The temporaral layer id to send to the outgoing stream (default: max layer available)
+	 * @param {Number} layers.temporalLayerId	- The temporal layer id to send to the outgoing stream (default: max layer available)
 	 * @param {Number} layers.maxSpatialLayerId	- Max spatial layer id (default: unlimited)
 	 * @param {Number} layers.maxTemporalLayerId	- Max temporal layer id (default: unlimited)
 	 */
@@ -230,7 +230,7 @@ class OutgoingStream extends Emitter
 	
 	/**
 	 * Get an array of the media stream audio tracks
-	 * @returns {Array|OutgoingStreamTracks}	- Array of tracks
+	 * @returns {OutgoingStreamTrack[]}	- Array of tracks
 	 */
 	getAudioTracks() 
 	{
@@ -248,7 +248,7 @@ class OutgoingStream extends Emitter
 	
 	/**
 	 * Get an array of the media stream video tracks
-	 * @returns {Array|OutgoingStreamTrack}	- Array of tracks
+	 * @returns {OutgoingStreamTrack[]}	- Array of tracks
 	 */
 	getVideoTracks() 
 	{
@@ -264,10 +264,10 @@ class OutgoingStream extends Emitter
 		return video;
 	}
 	
-	/*
-	 * Adds an incoming stream track created using the Transpocnder.createOutgoingStreamTrack to this stream
+	/**
+	 * Adds an incoming stream track created using [[Transponder.createOutgoingStreamTrack]] to this stream
 	 *  
-	 * @param {OuggoingStreamTrack} track
+	 * @param {OutgoingStreamTrack} track
 	 */
 	addTrack(track)
 	{
@@ -293,15 +293,7 @@ class OutgoingStream extends Emitter
 	/**
 	 * Create new track from a TrackInfo object and add it to this stream
 	 * @param {Object|TrackInfo|String} params Params plain object, StreamInfo object or media type
-	 * @param {String?} params.id		- Stream track id
-	 * @param {String?} params.mediaId	- Stream track media id (mid)
-	 * @param {String?} params.media	- Media type ("audio" or "video")
-	 * @param {Object?} params.ssrcs	- Override the generated ssrcs for this track
-	 * @param {Number?} params.ssrcs.media	- ssrc for the track
-	 * @param {Number?} params.ssrcs.rtx 	- ssrc for the rtx video track
-	 * @returns {OutgoingStream} The new outgoing stream
-	 * @param {TrackInfo} trackInfo Track info object
-	 * @returns {OugoingStreamTrack}
+	 * @returns The new outgoing stream
 	 */
 	createTrack(params)
 	{

--- a/lib/OutgoingStreamTrack.js
+++ b/lib/OutgoingStreamTrack.js
@@ -16,7 +16,48 @@ const {
 
 const Transponder	= require("./Transponder");
 
-function getSourceStats(source)
+/**
+ * @typedef {Object} TrackStats stats for media and rtx sources (if used)
+ * @property {number} timestamp timestamp on when this stats were created
+ * @property {MediaStats} media stats for the media stream
+ * @property {MediaStats} rtx stats for the RTX stream
+ * @property {number} [remb] remote estimated bitate (if remb is in use)
+ * @property {number} numFrames Total received frames
+ * @property {number} numFramesDelta Received frames during last second
+ * @property {number} numPackets number of rtp packets sent
+ * @property {number} numPacketsDelta number of rtp packets sent during last second 
+ * @property {number} rtt Round Trip Time in ms
+ * @property {number} bitrate Bitrate for media stream only in bps
+ * @property {number} total Accumulated bitrate for media and rtx streams in bps
+ */
+
+/**
+ * @typedef {Object} MediaStats stats for each RTP source
+ * @property {number} rtt Round Trip Time in ms
+ * @property {number} numFrames Total received frames
+ * @property {number} numFramesDelta Received frames during last second
+ * @property {number} numPackets Number of rtp packets sent
+ * @property {number} numPacketsDelta Number of rtp packets sent during last second
+ * @property {number} numRTCPPackets Number of rtcp packets sent
+ * @property {number} totalBytes Total rtp sent bytes
+ * @property {number} totalRTCPBytes Total rtp sent bytes
+ * @property {number} bitrate Average bitrate sent during last second in bps
+ * @property {number} reportCount Number of RTCP receiver reports received
+ * @property {number} reportCountDelta Number of RTCP receiver reports received during last second
+ * @property {ReceiverReport} [reported] Last report, if available
+ * 
+ */
+
+/**
+ * @typedef {Object} ReceiverReport RTP receiver report stats
+ * @property {number} lostCount Total packet loses reported
+ * @property {number} lostCountDelta Packet losses reported in last second
+ * @property {number} fractionLost Fraction loss media reported during last second
+ * @property {number} jitter Last reported jitter buffer value
+ */
+
+/** @returns {TrackStats} */
+function getSourceStats(/** @type {Native.RTPOutgoingSourceGroup} */ source)
 {
 	const mediaStats = getStatsFromOutgoingSource(source.media);
 	const rtxStats = getStatsFromOutgoingSource(source.rtx);
@@ -38,7 +79,8 @@ function getSourceStats(source)
 	};
 }
 
-function getStatsFromOutgoingSource(source) 
+/** @returns {MediaStats} */
+function getStatsFromOutgoingSource(/** @type {Native.RTPOutgoingSource} */ source) 
 {
 	return {
 		rtt			: source.rtt,
@@ -62,8 +104,15 @@ function getStatsFromOutgoingSource(source)
 }
 
 /**
+ * @typedef {Object} OutgoingStreamTrackEvents
+ * @property {(self: OutgoingStreamTrack, stats: TrackStats) => void} stopped
+ * @property {(muted: boolean) => void} muted
+ * @property {(bitrate: number, self: OutgoingStreamTrack) => void} remb
+ */
+
+/**
  * Audio or Video track of a media stream sent to a remote peer
- * @hideconstructor
+ * @extends {Emitter<OutgoingStreamTrackEvents>}
  */
 class OutgoingStreamTrack extends Emitter
 {
@@ -71,7 +120,12 @@ class OutgoingStreamTrack extends Emitter
 	 * @ignore
 	 * @hideconstructor
 	 */
-	constructor(media,id,mediaId,sender,source)
+	constructor(
+		/** @type {"audio" | "video"} */ media,
+		/** @type {string} */ id,
+		/** @type {string} */ mediaId,
+		/** @type {SharedPointer.Proxy<Native.RTPSenderShared>} */ sender,
+		/** @type {SharedPointer.Proxy<Native.RTPOutgoingSourceGroupShared>} */ source)
 	{
 		//Init emitter
 		super();
@@ -83,6 +137,7 @@ class OutgoingStreamTrack extends Emitter
 		this.sender	= sender;
 		this.source	= source;
 		this.muted	= false;
+		this.transponder = /** @type {Transponder | null} */ (null);
 		
 		//Create info
 		this.trackInfo = new TrackInfo(media, id);
@@ -102,7 +157,7 @@ class OutgoingStreamTrack extends Emitter
 		this.stats = getSourceStats(this.source);
 
 		//Native REMB event
-		this.onremb = (bitrate) => {
+		this.onremb = (/** @type {number} */ bitrate) => {
 			this.emit("remb",bitrate,this);
 		};
 	}
@@ -125,7 +180,6 @@ class OutgoingStreamTrack extends Emitter
 	
 	/**
 	* Get track media type
-	* @returns {String} "audio"|"video" 
 	*/
 	getMedia()
 	{
@@ -143,37 +197,7 @@ class OutgoingStreamTrack extends Emitter
 	
 	/**
 	 * Get stats for all encodings 
-	 * 
-	 * You will get stats for media and rtx sources (if used):
-	 *  - timestamp		: timestamp on when this stats where created
-	 *  - media		: mediaStats,
-	 *  - rtx		: rtxStats,
-	 *  - remb		: remote estimated bitate (if remb is in use)
-	 *  - numPackets	: number of rtp packets sent
-	 *  - numPacketsDelta	: number of rtp packets sent during last second 
-	 *  - rtt               : Round Trip Time in ms
-	 *  - bitrate		: Bitrate for media stream only in bps
-	 *  - total		: Accumulated bitrate for media and rtx streams in bps
-	 * 
-	 * The stats objects will privide the follwing info for each source
-	 *  - rtt			: Round Trip Time in ms
-	 *  - numFrames			: total recevied frames
-	 *  - numFramesDelta		: recevied frames during last second
-	 *  - numPackets		: number of rtp packets sent
-	 *  - numPacketsDelta		: number of rtp packets sent during last second
-	 *  - numRTCPPackets		: number of rtcp packets sent
-	 *  - totalBytes		: total rtp sent bytes
-	 *  - totalRTCPBytes		: total rtp sent bytes
-	 *  - bitrate			: average bitrate sent during last second in bps
-	 *  - reportCount		: number of RTCP receiver reports received
-	 *  - reportCountDelta		: number of RTCP receiver reports received during last second
-	 *  - reported			: last report, if available
-	 *  - reported.lostCount	: total packet loses reported
-	 *  - reported.lostCountDelta	: packet losses reported in last second
-	 *  - reported.fractionLost	: fraction loss media reported during last second
-	 *  - reported.jitter		: last reported jitter buffer value
-	 *  
-	 * @returns {Map<String,Object>} Map with stats by encodingId
+	 * @returns {TrackStats}
 	 */
 	getStats()
 	{
@@ -198,34 +222,7 @@ class OutgoingStreamTrack extends Emitter
 
 	/**
 	 * Get stats for all encodings 
-	 * 
-	 * You will get stats for media and rtx sources (if used):
-	 *  - timestmap		: timestamp on when this stats where created
-	 *  - media		: mediaStats,
-	 *  - rtx		: rtxStats,
-	 *  - remb		: remote estimated bitate (if remb is in use)
-	 *  - numPackets	: number of rtp packets sent
-	 *  - numPacketsDelta	: number of rtp packets sent during last second 
-	 *  - bitrate		: Bitrate for media stream only in bps
-	 *  - total		: Accumulated bitrate for media and rtx streams in bps
-	 * 
-	 * The stats objects will privide the follwing info for each source
-	 *  - numFrames			: total recevied frames
-	 *  - numFramesDelta		: recevied frames during last second
-	 *  - numPackets		: number of rtp packets sent
-	 *  - numPacketsDelta		: number of rtp packets sent during last second
-	 *  - numRTCPPackets		: number of rtcp packsets sent
-	 *  - totalBytes		: total rtp sent bytes
-	 *  - totalRTCPBytes		: total rtp sent bytes
-	 *  - bitrate			: average bitrate sent during last second in bps
-	 *  - reportCount		: number of RTCP receiver reports received
-	 *  - reportCountDelta		: number of RTCP receiver reports received during last second
-	 *  - reportedLostCount		: total packet loses reported
-	 *  - reportedLostCountDelta	: packet losses reported in last second
-	 *  - reportedFractionLost	: fraction loss media reported during last second
-	 *  - reportedJitter		: last reported jitter buffer value
-	 *  
-	 * @returns {Map<String,Object>} Map with stats by encodingId
+	 * @returns {Promise<TrackStats>}
 	 */
 	async getStatsAsync()
 	{
@@ -251,7 +248,7 @@ class OutgoingStreamTrack extends Emitter
 
 	/**
 	 * Return ssrcs associated to this track
-	 * @returns {Object}
+	 * @returns {import("./Transport").SSRCs}
 	 */
 	getSSRCs()
 	{
@@ -329,7 +326,7 @@ class OutgoingStreamTrack extends Emitter
 		return this.transponder;
 	}
 
-	forcePlayoutDelay(minDelay, maxDelay)
+	forcePlayoutDelay(/** @type {number} */ minDelay, /** @type {number} */ maxDelay)
 	{
 		this.source.SetForcedPlayoutDelay(minDelay, maxDelay);
 	}
@@ -337,14 +334,9 @@ class OutgoingStreamTrack extends Emitter
 	
 	/**
 	 * Listen media from the incoming stream track and send it to the remote peer of the associated transport.
-	 * This will stop any previous transpoder created by a previous attach.
-	 * @param {IncomingStreamTrack} incomingStreamTrack - The incoming stream to listen media for
-	 * @param {Object} layers			- [Optional] Only applicable to video tracks
-	 * @param {String} layers.encodingId		- rid value of the simulcast encoding of the track (default: first encoding available)
-	 * @param {Number} layers.spatialLayerId	- The spatial layer id to send to the outgoing stream (default: max layer available)
-	 * @param {Number} layers.temporalLayerId	- The temporal layer id to send to the outgoing stream (default: max layer available)
-	 * @param {Number} layers.maxSpatialLayerId	- Max spatial layer id (default: unlimited)
-	 * @param {Number} layers.maxTemporalLayerId	- Max temporal layer id (default: unlimited)
+	 * This will stop any previous transponder created by a previous attach.
+	 * @param {import("./IncomingStreamTrack")} incomingStreamTrack - The incoming stream to listen media for
+	 * @param {Transponder.LayerSelection} [layers]
 	 * @returns {Transponder} Track transponder object
 	 */
 	attachTo(incomingStreamTrack, layers)
@@ -380,8 +372,8 @@ class OutgoingStreamTrack extends Emitter
 	}
 	
 	/**
-	 * Get attached transpoder for this track
-	 * @returns {Transponder} Attached transpoder or null if not attached
+	 * Get attached transponder for this track
+	 * @returns {Transponder | null} Attached transponder or null if not attached
 	 */
 	getTransponder() 
 	{
@@ -419,7 +411,9 @@ class OutgoingStreamTrack extends Emitter
 		super.stop();
 		
 		//Remove transport reference, so destructor is called on GC
+		//@ts-expect-error
 		this.source = null;
+		//@ts-expect-error
 		this.sender = null;
 	}
 }

--- a/lib/OutgoingStreamTrack.js
+++ b/lib/OutgoingStreamTrack.js
@@ -145,30 +145,33 @@ class OutgoingStreamTrack extends Emitter
 	 * Get stats for all encodings 
 	 * 
 	 * You will get stats for media and rtx sources (if used):
-	 *  - timestmap		: timestamp on when this stats where created
+	 *  - timestamp		: timestamp on when this stats where created
 	 *  - media		: mediaStats,
 	 *  - rtx		: rtxStats,
 	 *  - remb		: remote estimated bitate (if remb is in use)
 	 *  - numPackets	: number of rtp packets sent
 	 *  - numPacketsDelta	: number of rtp packets sent during last second 
+	 *  - rtt               : Round Trip Time in ms
 	 *  - bitrate		: Bitrate for media stream only in bps
 	 *  - total		: Accumulated bitrate for media and rtx streams in bps
 	 * 
 	 * The stats objects will privide the follwing info for each source
+	 *  - rtt			: Round Trip Time in ms
 	 *  - numFrames			: total recevied frames
 	 *  - numFramesDelta		: recevied frames during last second
 	 *  - numPackets		: number of rtp packets sent
 	 *  - numPacketsDelta		: number of rtp packets sent during last second
-	 *  - numRTCPPackets		: number of rtcp packsets sent
+	 *  - numRTCPPackets		: number of rtcp packets sent
 	 *  - totalBytes		: total rtp sent bytes
 	 *  - totalRTCPBytes		: total rtp sent bytes
 	 *  - bitrate			: average bitrate sent during last second in bps
 	 *  - reportCount		: number of RTCP receiver reports received
 	 *  - reportCountDelta		: number of RTCP receiver reports received during last second
-	 *  - reportedLostCount		: total packet loses reported
-	 *  - reportedLostCountDelta	: packet losses reported in last second
-	 *  - reportedFractionLost	: fraction loss media reported during last second
-	 *  - reportedJitter		: last reported jitter buffer value
+	 *  - reported			: last report, if available
+	 *  - reported.lostCount	: total packet loses reported
+	 *  - reported.lostCountDelta	: packet losses reported in last second
+	 *  - reported.fractionLost	: fraction loss media reported during last second
+	 *  - reported.jitter		: last reported jitter buffer value
 	 *  
 	 * @returns {Map<String,Object>} Map with stats by encodingId
 	 */
@@ -268,7 +271,7 @@ class OutgoingStreamTrack extends Emitter
 		return this.muted;
 	}
 	
-	/*
+	/**
 	 * Mute/Unmute track
 	 * This operation will not change the muted state of the stream this track belongs too.
 	 * @param {boolean} muting - if we want to mute or unmute
@@ -339,7 +342,7 @@ class OutgoingStreamTrack extends Emitter
 	 * @param {Object} layers			- [Optional] Only applicable to video tracks
 	 * @param {String} layers.encodingId		- rid value of the simulcast encoding of the track (default: first encoding available)
 	 * @param {Number} layers.spatialLayerId	- The spatial layer id to send to the outgoing stream (default: max layer available)
-	 * @param {Number} layers.temporalLayerId	- The temporaral layer id to send to the outgoing stream (default: max layer available)
+	 * @param {Number} layers.temporalLayerId	- The temporal layer id to send to the outgoing stream (default: max layer available)
 	 * @param {Number} layers.maxSpatialLayerId	- Max spatial layer id (default: unlimited)
 	 * @param {Number} layers.maxTemporalLayerId	- Max temporal layer id (default: unlimited)
 	 * @returns {Transponder} Track transponder object

--- a/lib/PeerConnectionServer.js
+++ b/lib/PeerConnectionServer.js
@@ -1,3 +1,4 @@
+const Transport		= require("./Transport");
 const Emitter		= require("medooze-event-emitter");
 const LFSR		= require('lfsr');
 const { v4: uuidV4 }	= require("uuid");
@@ -16,9 +17,15 @@ const {
 	SourceGroupInfo,
 } = require("semantic-sdp");
 
+/**
+ * @typedef {Object} PeerConnectionServerEvents
+ * @property {(self: PeerConnectionServer) => void} stopped
+ * @property {(transport: Transport) => void} transport New managed transport has been created by a remote peer connection client
+ */
 
 /**
  * Manager of remote peer connecion clients
+ * @extends {Emitter<PeerConnectionServerEvents>}
  */
 class PeerConnectionServer extends Emitter
 {
@@ -27,7 +34,10 @@ class PeerConnectionServer extends Emitter
 	 * @hideconstructor
 	 * private constructor
 	 */
-	constructor(endpoint,tm,capabilities)
+	constructor(
+		/** @type {import("./Endpoint")} */ endpoint,
+		/** @type {any} */ tm,
+		/** @type {SemanticSDP.Capabilities} */ capabilities)
 	{
 		//Init emitter
 		super();
@@ -39,7 +49,7 @@ class PeerConnectionServer extends Emitter
 		this.tm = tm;
 		
 		//The created transports
-		this.transports = new Set();
+		this.transports = /** @type {Set<Transport>} */ (new Set());
 		
 		//Create our namespace
 		this.ns = tm.namespace("medooze::pc");
@@ -221,8 +231,10 @@ class PeerConnectionServer extends Emitter
 		super.stop();
 		
 		//Null
+		//@ts-expect-error
 		this.transports = null;
 		this.ns = null;
+		//@ts-expect-error
 		this.endpoint = null;
 	}
 }

--- a/lib/Player.js
+++ b/lib/Player.js
@@ -9,7 +9,13 @@ const {
 } = require("semantic-sdp");
 
 /**
- * MP4 recorder that allows to record several streams/tracks on a single mp4 file
+ * @typedef {Object} PlayerEvents
+ * @property {(self: Player) => void} stopped
+ * @property {(self: Player) => void} ended Playback ended
+ */
+
+/**
+ * @extends {Emitter<PlayerEvents>}
  */
 class Player extends Emitter
 {
@@ -18,7 +24,7 @@ class Player extends Emitter
 	 * @hideconstructor
 	 * private constructor
 	 */
-	constructor(filename)
+	constructor(/** @type {string} */ filename)
 	{
 		//Init emitter
 		super();
@@ -37,7 +43,7 @@ class Player extends Emitter
 			throw new Error("MP4 filenamec could not be opened");
 		
 		//init track list
-		this.tracks = new Map();
+		this.tracks = /** @type {Map<string, IncomingStreamTrack>} */ (new Map());
 		
 		//Check if player has video track
 		if (this.player.HasVideoTrack())
@@ -210,6 +216,7 @@ class Player extends Emitter
 		super.stop();
 		
 		//Free
+		//@ts-expect-error
 		this.player = null;
 	}
 	

--- a/lib/Recorder.js
+++ b/lib/Recorder.js
@@ -4,8 +4,28 @@ const IncomingStream    = require("./IncomingStream");
 const RecorderTrack	= require("./RecorderTrack");
 const Refresher		= require("./Refresher");
 const SharedPointer	= require("./SharedPointer");
+const IncomingStreamTrack = require("./IncomingStreamTrack");
+
+//@ts-expect-error
+const parseInt = /** @type {(x: number) => number} */ (global.parseInt);
+
+/**
+ * @typedef {Object} RecorderParams
+ * @property {number} [refresh] Periodically refresh an intra on all video tracks (in ms)
+ * @property {boolean} [waitForIntra] Wait until first video iframe is received to start recording media
+ * @property {number} [timeShift] Buffer time in ms. Recording must be splicity started with flush() call
+ * @property {boolean} [disableHints] Disable recording hint tracks. Note that this file won't be playable with the Player object;
+ */
+
+/**
+ * @typedef {Object} RecorderEvents
+ * @property {(self: Recorder) => void} stopped
+ * @property {(self: Recorder, timestamp: number) => void} started Recorder started event. This event will be triggered when the first media frame is being recorded. (`timestamp` is the timestamp of the first frame in milliseconds).
+ */
+
 /**
  * MP4 recorder that allows to record several streams/tracks on a single mp4 file
+ * @extends {Emitter<RecorderEvents>}
  */
 class Recorder extends Emitter
 {
@@ -14,7 +34,9 @@ class Recorder extends Emitter
 	 * @hideconstructor
 	 * private constructor
 	 */
-	constructor(filename,params)
+	constructor(
+		/** @type {string} */ filename,
+		/** @type {RecorderParams | undefined} */ params = undefined)
 	{
 		//Init emitter
 		super();
@@ -60,7 +82,7 @@ class Recorder extends Emitter
 			this.refresher = new Refresher(this.params.refresh);
 		
 		//Listener for player facade events
-		this.onstarted = (timestamp) => {
+		this.onstarted = (/** @type {number} */ timestamp) => {
 			this.emit("started",this,timestamp);
 		};
 	}
@@ -120,11 +142,12 @@ class Recorder extends Emitter
 	/**
 	 * Start recording and incoming
 	 * @param {IncomingStream|IncomingStreamTrack} incomingStreamOrTrack - Incomining stream or track to be recordeds
+	 * @param {{ multitrack?: boolean }} [options]
 	 * @returns {Array<RecorderTrack>} 
 	 */
 	record(incomingStreamOrTrack, options)
 	{
-		const tracks = [];
+		const tracks = /** @type {RecorderTrack[]} */ ([]);
 
 		//Set defaults
 		options = Object.assign({
@@ -212,7 +235,7 @@ class Recorder extends Emitter
 
 	/**
 	 * Stop recording and close file. NOTE: File will be flsuh async,
-	 * @returns {undefined} -  TODO: return promise when flush is ended
+	 * @returns {Promise<void>} -  TODO: return promise when flush is ended
 	 */
 	async stop()
 	{
@@ -244,7 +267,9 @@ class Recorder extends Emitter
 		super.stop();
 		
 		//Free
+		//@ts-expect-error
 		this.refresher = null;
+		//@ts-expect-error
 		this.recorder = null;
 	}
 	

--- a/lib/RecorderTrack.js
+++ b/lib/RecorderTrack.js
@@ -1,8 +1,17 @@
 const Native	= require("./Native");
 const Emitter	= require("medooze-event-emitter");
+const SharedPointer = require("./SharedPointer");
+const IncomingStreamTrack = require("./IncomingStreamTrack");
+
+/**
+ * @typedef {Object} RecorderTrackEvents
+ * @property {(self: RecorderTrack) => void} stopped
+ * @property {(muted: boolean) => void} muted
+ */
 
 /**
  * Track of the recorder associated to an incoming strem track
+ * @extends {Emitter<RecorderTrackEvents>}
  */
 class RecorderTrack extends Emitter
 {
@@ -11,7 +20,11 @@ class RecorderTrack extends Emitter
 	 * @hideconstructor
 	 * private constructor
 	 */
-	constructor(id,track,depacketizer,recorder)
+	constructor(
+		/** @type {number} */ id,
+		/** @type {IncomingStreamTrack} */ track,
+		/** @type {SharedPointer.Proxy<Native.RTPIncomingMediaStreamDepacketizerShared>} */ depacketizer,
+		/** @type {Native.MP4RecorderFacadeShared} */ recorder)
 	{
 		//Init emitter
 		super();
@@ -111,8 +124,11 @@ class RecorderTrack extends Emitter
 		super.stop();
 		
 		//Remove track
+		//@ts-expect-error
 		this.track = null;
+		//@ts-expect-error
 		this.depacketizer = null;
+		//@ts-expect-error
 		this.recorder = null;
 	}
 	

--- a/lib/Refresher.js
+++ b/lib/Refresher.js
@@ -1,8 +1,16 @@
 const IncomingStream		= require("./IncomingStream");
 const IncomingStreamTrack	= require("./IncomingStreamTrack");
 const Emitter		= require("medooze-event-emitter");
+
+/**
+ * @typedef {Object} RefresherEvents
+ * @property {(self: Refresher) => void} stopped
+ * @property {(self: Refresher) => void} refreshing A refresh is taking place
+ */
+
 /**
  * Periodically request an I frame on all incoming stream or tracks
+ * @extends {Emitter<RefresherEvents>}
  */
 class Refresher extends Emitter
 {
@@ -11,16 +19,16 @@ class Refresher extends Emitter
 	 * @hideconstructor
 	 * private constructor
 	 */
-	constructor(period)
+	constructor(/** @type {number} */ period)
 	{
 		//Init emitter
 		super();
 
 		//No tracks
-		this.tracks = new Set();
+		this.tracks = /** @type {Set<IncomingStreamTrack>} */ (new Set());
 		
 		//Listener for stop track events
-		this.ontrackstopped = (track) => {
+		this.ontrackstopped = (/** @type {IncomingStreamTrack} */ track) => {
 			//Remove from set
 			this.tracks.delete(track);
 		};
@@ -31,7 +39,7 @@ class Refresher extends Emitter
 
 	/**
 	 * Restart refreshing interval
-	 * @param {Number} timeout - Refresh pedior in ms
+	 * @param {Number} period - Refresh period in ms
 	 */
 	restart(period)
 	{
@@ -50,7 +58,7 @@ class Refresher extends Emitter
 
 	/**
 	 * Add stream or track to request 
-	 * @param {IncomintgStream|IncomingStreamTrack} streamOrTrack 
+	 * @param {IncomingStream|IncomingStreamTrack} streamOrTrack 
 	 */
 	add(streamOrTrack)
 	{
@@ -76,7 +84,7 @@ class Refresher extends Emitter
 
 	/**
 	 * Remove stream or track to request 
-	 * @param {IncomintgStream|IncomingStreamTrack} streamOrTrack 
+	 * @param {IncomingStream|IncomingStreamTrack} streamOrTrack 
 	 */
 	remove(streamOrTrack)
 	{
@@ -119,6 +127,7 @@ class Refresher extends Emitter
 		super.stop();
 			
 		//Clean set
+		//@ts-expect-error
 		this.tracks = null;
 	}
 }

--- a/lib/SDPManager.js
+++ b/lib/SDPManager.js
@@ -1,7 +1,20 @@
 const Emitter	= require("medooze-event-emitter");
+const SemanticSDP	= require("semantic-sdp");
+
+/** @typedef {import("./Transport")} Transport */
+
+/** @typedef {"initial" | "local-offer" | "remote-offer" | "stable"} SDPState */
+
+/**
+ * @typedef {Object} SDPManagerEvents
+ * @property {(self: SDPManager) => void} stopped
+ * @property {(transport: Transport) => void} transport
+ * @property {(transport: Transport) => void} renegotiationneeded
+ */
 
 /**
  * SDPManager
+ * @extends {Emitter<SDPManagerEvents>}
  */
 class SDPManager extends Emitter
 {
@@ -16,12 +29,15 @@ class SDPManager extends Emitter
 		super();
 
 		//SDP O/A state
+		/** @type {SDPState} */
 		this.state = "initial";
+
+		/** @type {Transport | null} */
+		this.transport = null;
 	}
 	
 	/**
 	 * Get current SDP offer/answer state 
-	 * @returns {String} one of "initial","local-offer","remote-offer","stabable".
 	 */
 	getState()
 	{
@@ -30,7 +46,7 @@ class SDPManager extends Emitter
 	
 	/**
 	 * Returns the Transport object created by the SDP O/A
-	 * @returns {Transport}
+	 * @returns {Transport | null}
 	 */
 	getTransport()
 	{
@@ -41,13 +57,17 @@ class SDPManager extends Emitter
 	 * Create local description
 	 * @return {String}
 	 */
-	createLocalDescription(){}
+	createLocalDescription(){
+		throw new Error('not implemented');
+	}
 	
 	/**
 	 * Process remote offer
 	 * @param {String} sdp	- Remote session description
 	 */
-	processRemoteDescription(sdp){}
+	processRemoteDescription(sdp){
+		throw new Error('not implemented');
+	}
 	
 	/**
 	 * Stop manager and associated tranports

--- a/lib/SDPManager.js
+++ b/lib/SDPManager.js
@@ -37,13 +37,13 @@ class SDPManager extends Emitter
 		return this.transport;
 	}
 	
-	/*
+	/**
 	 * Create local description
 	 * @return {String}
 	 */
 	createLocalDescription(){}
 	
-	/*
+	/**
 	 * Process remote offer
 	 * @param {String} sdp	- Remote session description
 	 */

--- a/lib/SDPManagerPlanB.js
+++ b/lib/SDPManagerPlanB.js
@@ -14,9 +14,14 @@ const {
 	SourceGroupInfo,
 } = require("semantic-sdp");
 
+/** @typedef {import("./Endpoint")} Endpoint */
+/** @typedef {import("./Transport")} Transport */
+
 class SDPManagerPlanB extends SDPManager
 {
-	constructor(endpoint,capabilities)
+	constructor(
+		/** @type {Endpoint} */ endpoint,
+		/** @type {SemanticSDP.Capabilities} */ capabilities)
 	{
 		//Init parent
 		super();
@@ -28,8 +33,11 @@ class SDPManagerPlanB extends SDPManager
 		//Renegotiation needed flag
 		this.renegotiationNeeded = false;
 		
+		/** @type {SDPInfo | undefined} */
+		this.localInfo = undefined;
 	}
 
+	/** @override */
 	createLocalDescription()
 	{
 		//If there is no local info
@@ -70,7 +78,8 @@ class SDPManagerPlanB extends SDPManager
 		return this.localInfo.toString();
 	}
 	
-	processRemoteDescription(sdp)
+	/** @override */
+	processRemoteDescription(/** @type {string} */ sdp)
 	{
 		//Renegotiate
 		const renegotiate = () => {
@@ -203,6 +212,7 @@ class SDPManagerPlanB extends SDPManager
 	}
 	
 	
+	/** @override */
 	stop()
 	{
 		//Stop transport
@@ -214,6 +224,7 @@ class SDPManagerPlanB extends SDPManager
 		
 		//Free it
 		this.transport = null;
+		//@ts-expect-error
 		this.endpoint = null;
 	}
 }

--- a/lib/SDPManagerUnified.js
+++ b/lib/SDPManagerUnified.js
@@ -15,9 +15,38 @@ const {
 	Direction,
 } = require("semantic-sdp");
 
+/** @typedef {import("./Endpoint")} Endpoint */
+/** @typedef {import("./Transport")} Transport */
+
+/**
+ * @typedef {Object} Transceiver
+ * @property {String} mid
+ * @property {SemanticSDP.MediaType} media
+ * @property {TransceiverLocal} local
+ * @property {TransceiverRemote} remote
+ */
+
+/**
+ * @typedef {Object} TransceiverLocal
+ * @property {String} [streamId]
+ * @property {import("./OutgoingStream")} [stream]
+ * @property {import("./OutgoingStreamTrack")} [track]
+ * @property {MediaInfo} [info]
+ */
+
+/**
+ * @typedef {Object} TransceiverRemote
+ * @property {String} [streamId]
+ * @property {import("./IncomingStream")} [stream]
+ * @property {import("./IncomingStreamTrack")} [track]
+ * @property {MediaInfo} [info]
+ */
+
 class SDPManagerUnified extends SDPManager
 {
-	constructor(endpoint,capabilities)
+	constructor(
+		/** @type {Endpoint} */ endpoint,
+		/** @type {SemanticSDP.Capabilities} */ capabilities)
 	{
 		//Init parent
 		super();
@@ -26,11 +55,11 @@ class SDPManagerUnified extends SDPManager
 		this.endpoint = endpoint;
 		this.capabilities = capabilities;
 		//The list of transceivers
-		this.transceivers = [];
+		this.transceivers = /** @type {Transceiver[]} */ ([]);
 		//The pending list of local tracks not assigned to transceivers
-		this.pending = new Set();
+		this.pending = /** @type {Set<{ stream: import("./OutgoingStream"), track: import("./OutgoingStreamTrack") }>} */ (new Set());
 		//Set of removed local tracks
-		this.removed = new Set();
+		this.removed = /** @type {Set<import("./OutgoingStreamTrack")>} */ (new Set());
 		
 		//Renegotiation needed flag
 		this.renegotiationNeeded = false;
@@ -38,6 +67,7 @@ class SDPManagerUnified extends SDPManager
 	}
 	
 	
+	/** @override */
 	createLocalDescription()
 	{
 		//If there is no local info
@@ -50,11 +80,12 @@ class SDPManagerUnified extends SDPManager
 				candidates	: this.endpoint.getLocalCandidates()
 			});
 			//For each media capability
-			for (const media of Object.keys(this.capabilities))
+			for (const media of /** @type {SemanticSDP.MediaType[]} */ (Object.keys(this.capabilities)))
 			{
 				//New mid
 				const mid = String(this.transceivers.length);
 				//Create new transceiver
+				/** @type {Transceiver} */
 				const transceiver = {
 					mid	: mid,
 					media	: media,
@@ -178,11 +209,12 @@ class SDPManagerUnified extends SDPManager
 					//Receive only
 					mediaInfo.setDirection(Direction.SENDONLY);
 				//Get stream info
-				let streamInfo = this.localInfo.getStream(transceiver.local.stream.getId());
+				const id = transceiver.local.stream.getId();
+				let streamInfo = this.localInfo.getStream(id);
 				//If not present yet
 				if (!streamInfo)
 					//Create new info
-					streamInfo = new StreamInfo(transceiver.local.stream.getId());
+					streamInfo = new StreamInfo(id);
 				//Add stream to media
 				this.localInfo.addStream(streamInfo);
 				//Get info
@@ -243,7 +275,8 @@ class SDPManagerUnified extends SDPManager
 		}
 	}
 	
-	processRemoteDescription(sdp)
+	/** @override */
+	processRemoteDescription(/** @type {string} */ sdp)
 	{
 		//Parse sdp
 		this.remoteInfo = SDPInfo.parse(sdp);
@@ -415,6 +448,7 @@ class SDPManagerUnified extends SDPManager
 		return this.remoteInfo.toString();
 	}
 	
+	/** @override */
 	stop()
 	{
 		//Stop transport
@@ -426,6 +460,7 @@ class SDPManagerUnified extends SDPManager
 		
 		//Free it
 		this.transport = null;
+		//@ts-expect-error
 		this.endpoint = null;
 	}
 }

--- a/lib/SharedPointer.js
+++ b/lib/SharedPointer.js
@@ -1,3 +1,5 @@
+//@ts-nocheck
+
 function proxy(ret,cache)
 {
 	if (typeof ret === "object" && ret.constructor.name.match(/_exports_(.*)Shared/))
@@ -39,7 +41,23 @@ class Handler
 };
 
 
-function SharedPointer(obj, cache)
+/**
+ * @template {{ get(): U }} T
+ * @typedef {T & ReturnType<T['get']>} Proxy
+ *
+ * objects returned by {@link SharedPointer} are proxies that
+ * implement both the operations of the shared pointer itself
+ * and of the pointed-to object. they can be used in place of
+ * both.
+ */
+
+/**
+ * @template {{ get(): U }} T
+ * @returns {Proxy<T>}
+ */
+function SharedPointer(
+	/** @type {T} */ obj,
+	/** @type {Map<Object, Proxy>} */ cache)
 {
 	//If what we get passed is already a proxy, return it unchanged
 	if (obj[SharedPointer.Target])

--- a/lib/Transponder.js
+++ b/lib/Transponder.js
@@ -80,7 +80,7 @@ class Transponder extends Emitter
 	 * @param {Object} layers			- [Optional] Only applicable to video tracks
 	 * @param {String} layers.encodingId		- rid value of the simulcast encoding of the track (default: first encoding available)
 	 * @param {Number} layers.spatialLayerId	- The spatial layer id to send to the outgoing stream (default: max layer available)
-	 * @param {Number} layers.temporalLayerId	- The temporaral layer id to send to the outgoing stream (default: max layer available)
+	 * @param {Number} layers.temporalLayerId	- The temporal layer id to send to the outgoing stream (default: max layer available)
 	 * @param {Number} layers.maxSpatialLayerId	- Max spatial layer id (default: unlimited)
 	 * @param {Number} layers.maxTemporalLayerId	- Max temporal layer id (default: unlimited)
 	 * @param {Boolean} smooth - Wait until next valid frame before switching to the new encoding
@@ -244,14 +244,14 @@ class Transponder extends Emitter
 	}
 
 	/**
-	 * Select encoding and temporal and spatial layers based on the desired bitrate. This operation will unmute the transponder if it was mutted and it is possible to select an encoding and layer based on the target bitrate and options.
+	 * Select encoding and temporal and spatial layers based on the desired bitrate. This operation will unmute the transponder if it was muted and it is possible to select an encoding and layer based on the target bitrate and options.
 	 * 
-	 * @param {Number} bitrate
+	 * @param {Number} target Target bitrate
 	 * @param {Object} options - Options for configuring algorithm to select best encoding/layers [Optional]
 	 * @param {Object} options.traversal - Traversal algorithm "default", "spatial-temporal", "zig-zag-spatial-temporal", "temporal-spatial", "zig-zag-temporal-spatial" [Default: "default"]
 	 * @param {Object} options.strict    - If there is not a layer with a bitrate lower thatn target, stop sending media [Default: false]
 	 * @param {Object} options.smooth    - When going to a lower simulcast layer, keep the higher one visible [Default: true]
-	 * @returns {Number} Current bitrate of the selected encoding and layers, it aslo incudes the selected layer indexes and available layers as properties of the Number object.
+	 * @returns {Number} Current bitrate of the selected encoding and layers, it also includes the selected layer indexes and available layers as properties of the Number object.
 	 */
 	setTargetBitrate(target, options) 
 	{
@@ -597,7 +597,7 @@ class Transponder extends Emitter
 	 * @param {Object} layers			- [Optional] Only applicable to video tracks
 	 * @param {String} layers.encodingId		- rid value of the simulcast encoding of the track (default: the current one)
 	 * @param {Number} layers.spatialLayerId	- The spatial layer id to send to the outgoing stream (default: max layer available)
-	 * @param {Number} layers.temporalLayerId	- The temporaral layer id to send to the outgoing stream (default: max layer available)
+	 * @param {Number} layers.temporalLayerId	- The temporal layer id to send to the outgoing stream (default: max layer available)
 	 * @param {Number} layers.maxSpatialLayerId	- Max spatial layer id (default: unlimited)
 	 * @param {Number} layers.maxTemporalLayerId	- Max temporal layer id (default: unlimited)
 	 * @param {Boolean} smooth			- Wait until next valid frame before switching to the new encoding
@@ -714,7 +714,7 @@ class Transponder extends Emitter
 	/**
 	 * Select SVC temporatl and spatial layers. Only available for VP9 media.
 	 * @param {Number} spatialLayerId The spatial layer id to send to the outgoing stream
-	 * @param {Number} temporalLayerId The temporaral layer id to send to the outgoing stream
+	 * @param {Number} temporalLayerId The temporal layer id to send to the outgoing stream
 	 */
 	selectLayer(spatialLayerId,temporalLayerId)
 	{

--- a/lib/Transponder.js
+++ b/lib/Transponder.js
@@ -7,6 +7,24 @@ const IncomingStreamTrack = require("./IncomingStreamTrack");
 /** @typedef {IncomingStreamTrack.LayerStats} LayerStats */
 
 /**
+ * @typedef {Object} LayerSelection
+ * Object describing which layers to forward (only applies to video tracks, ignored otherwise).
+ *
+ * @property {string} encodingId rid value of the simulcast encoding of the track (default: first encoding available, or for {@link Transponder.select}, the current encoding (no change))
+ * @property {number} spatialLayerId The spatial layer id to send to the outgoing stream (default: max layer available)
+ * @property {number} temporalLayerId The temporal layer id to send to the outgoing stream (default: max layer available)
+ * @property {number} maxSpatialLayerId Max spatial layer id (default: unlimited)
+ * @property {number} maxTemporalLayerId Max temporal layer id (default: unlimited)
+ */
+
+/**
+ * @typedef {Object} SetTargetBitrateOptions Options for configuring algorithm to select best encoding/layers
+ * @property {"default" | "spatial-temporal" | "zig-zag-spatial-temporal" | "temporal-spatial" | "zig-zag-temporal-spatial"} [traversal] Traversal algorithm [Default: "default"]
+ * @property {boolean} [strict] If there is not a layer with a bitrate lower thatn target, stop sending media [Default: false]
+ * @property {boolean} [smooth] When going to a lower simulcast layer, keep the higher one visible [Default: true]
+ */
+
+/**
  * @typedef {Object} TransponderEvents
  * @property {(muted: boolean) => void} muted
  * @property {(self: Transponder) => void} stopped
@@ -36,6 +54,7 @@ class Transponder extends Emitter
 		this.media = media;
 		//No track
 		this.track = /** @type {IncomingStreamTrack | null} */ (null);
+		this.encodingId = /** @type {string | null} */ (null);
 		this.muted = false;
 		this.spatialLayerId = LayerInfo.MaxLayerId;
 		this.temporalLayerId = LayerInfo.MaxLayerId;
@@ -58,7 +77,10 @@ class Transponder extends Emitter
 			this.encodingId = null;
 		};
 		//Listener for when new encodings become avialable
-		this.onAttachedTrackEncoding = (incomingStreamTrack,encoding) => {
+		this.onAttachedTrackEncoding = (
+			/** @type {IncomingStreamTrack} */ incomingStreamTrack,
+			/** @type {IncomingStreamTrack.Encoding} */ encoding,
+		) => {
 			//If we don't have an encoding yet
 			if (this.track === incomingStreamTrack && (!this.encodingId || this.encodingId == encoding.id))
 			{
@@ -76,14 +98,9 @@ class Transponder extends Emitter
 	
 	/**
 	 * Set incoming track
-	 * @param {IncomingStreamTrack} track		- Incoming track to attach to
-	 * @param {Object} layers			- [Optional] Only applicable to video tracks
-	 * @param {String} layers.encodingId		- rid value of the simulcast encoding of the track (default: first encoding available)
-	 * @param {Number} layers.spatialLayerId	- The spatial layer id to send to the outgoing stream (default: max layer available)
-	 * @param {Number} layers.temporalLayerId	- The temporal layer id to send to the outgoing stream (default: max layer available)
-	 * @param {Number} layers.maxSpatialLayerId	- Max spatial layer id (default: unlimited)
-	 * @param {Number} layers.maxTemporalLayerId	- Max temporal layer id (default: unlimited)
-	 * @param {Boolean} smooth - Wait until next valid frame before switching to the new encoding
+	 * @param {IncomingStreamTrack | null} track		- Incoming track to attach to, or null to detach
+	 * @param {LayerSelection} [layers]
+	 * @param {Boolean} [smooth] - Wait until next valid frame before switching to the new encoding
 	 */
 	setIncomingTrack(track, layers, smooth)
 	{
@@ -247,11 +264,8 @@ class Transponder extends Emitter
 	 * Select encoding and temporal and spatial layers based on the desired bitrate. This operation will unmute the transponder if it was muted and it is possible to select an encoding and layer based on the target bitrate and options.
 	 * 
 	 * @param {Number} target Target bitrate
-	 * @param {Object} options - Options for configuring algorithm to select best encoding/layers [Optional]
-	 * @param {Object} options.traversal - Traversal algorithm "default", "spatial-temporal", "zig-zag-spatial-temporal", "temporal-spatial", "zig-zag-temporal-spatial" [Default: "default"]
-	 * @param {Object} options.strict    - If there is not a layer with a bitrate lower thatn target, stop sending media [Default: false]
-	 * @param {Object} options.smooth    - When going to a lower simulcast layer, keep the higher one visible [Default: true]
-	 * @returns {Number} Current bitrate of the selected encoding and layers, it also includes the selected layer indexes and available layers as properties of the Number object.
+	 * @param {SetTargetBitrateOptions} [options]
+	 * @returns {ReturnType<NumberConstructor>} Current bitrate of the selected encoding and layers, it also includes the selected layer indexes and available layers as properties of the Number object.
 	 */
 	setTargetBitrate(target, options) 
 	{
@@ -418,14 +432,11 @@ class Transponder extends Emitter
 	}
 
 	/**
-	 * Select encoding and temporal and spatial layers based on the desired bitrate. This operation will unmute the transponder if it was mutted and it is possible to select an encoding and layer based on the target bitrate and options.
+	 * Select encoding and temporal and spatial layers based on the desired bitrate. This operation will unmute the transponder if it was muted and it is possible to select an encoding and layer based on the target bitrate and options.
 	 * 
-	 * @param {Number} bitrate
-	 * @param {Object} options - Options for configuring algorithm to select best encoding/layers [Optional]
-	 * @param {Object} options.traversal - Traversal algorithm "default", "spatial-temporal", "zig-zag-spatial-temporal", "temporal-spatial", "zig-zag-temporal-spatial" [Default: "default"]
-	 * @param {Object} options.strict    - If there is not a layer with a bitrate lower thatn target, stop sending media [Default: false]
-	 * @param {Object} options.smooth    - When going to a lower simulcast layer, keep the higher one visible [Default: true]
-	 * @returns Promise<{Number}> Current bitrate of the selected encoding and layers, it aslo incudes the selected layer indexes and available layers as properties of the Number object.
+	 * @param {Number} target Target bitrate
+	 * @param {SetTargetBitrateOptions} [options]
+	 * @returns {Promise<Number>} Current bitrate of the selected encoding and layers, it also includes the selected layer indexes and available layers as properties of the Number object.
 	 */
 	async setTargetBitrateAsync(target, options) 
 	{
@@ -594,13 +605,8 @@ class Transponder extends Emitter
 
 	/**
 	 * Select the simulcast encoding layer and svc layers
-	 * @param {Object} layers			- [Optional] Only applicable to video tracks
-	 * @param {String} layers.encodingId		- rid value of the simulcast encoding of the track (default: the current one)
-	 * @param {Number} layers.spatialLayerId	- The spatial layer id to send to the outgoing stream (default: max layer available)
-	 * @param {Number} layers.temporalLayerId	- The temporal layer id to send to the outgoing stream (default: max layer available)
-	 * @param {Number} layers.maxSpatialLayerId	- Max spatial layer id (default: unlimited)
-	 * @param {Number} layers.maxTemporalLayerId	- Max temporal layer id (default: unlimited)
-	 * @param {Boolean} smooth			- Wait until next valid frame before switching to the new encoding
+	 * @param {LayerSelection} layers
+	 * @param {Boolean} [smooth]			- Wait until next valid frame before switching to the new encoding
 	 */
 	select(layers,smooth)
 	{
@@ -647,8 +653,8 @@ class Transponder extends Emitter
 	}
 	
 	/**
-	 * Return the encoding that is being forwarded
-	 * @returns {String} encodingId
+	 * Return the encoding that is being forwarded, or null if no track attached
+	 * @returns {String | null} encodingId
 	 */
 	getSelectedEncoding()
 	{
@@ -695,7 +701,6 @@ class Transponder extends Emitter
 
 	/**
 	 * Get current selected layer info
-	 * @returns {Object} 
 	 */
 	async getSelectedLayerAsync()
 	{

--- a/lib/Transponder.js
+++ b/lib/Transponder.js
@@ -1,9 +1,20 @@
 const SharedPointer	= require("./SharedPointer");
 const Emitter		= require("medooze-event-emitter");
 const LayerInfo		= require("./LayerInfo");
+const Native		= require("./Native");
+const IncomingStreamTrack = require("./IncomingStreamTrack");
+
+/** @typedef {IncomingStreamTrack.LayerStats} LayerStats */
+
+/**
+ * @typedef {Object} TransponderEvents
+ * @property {(muted: boolean) => void} muted
+ * @property {(self: Transponder) => void} stopped
+ */
 
 /**
  * Transponder copies data from an incoming track to an outgoing track and allows stream modifications
+ * @extends {Emitter<TransponderEvents>}
  */
 class Transponder extends Emitter
 {
@@ -12,7 +23,9 @@ class Transponder extends Emitter
 	 * @hideconstructor
 	 * private constructor
 	 */
-	constructor(transponder, media)
+	constructor(
+		/** @type {Native.RTPStreamTransponderFacade} */ transponder,
+		/** @type {"audio"|"video"} */ media)
 	{
 		//Init emitter
 		super();
@@ -22,7 +35,7 @@ class Transponder extends Emitter
 		//The media type
 		this.media = media;
 		//No track
-		this.track = null;
+		this.track = /** @type {IncomingStreamTrack | null} */ (null);
 		this.muted = false;
 		this.spatialLayerId = LayerInfo.MaxLayerId;
 		this.temporalLayerId = LayerInfo.MaxLayerId;
@@ -159,7 +172,6 @@ class Transponder extends Emitter
 
 	/**
 	* Get Transponder media type
-	* @returns {String} "audio"|"video" 
 	*/
 	getMedia()
 	{
@@ -168,7 +180,7 @@ class Transponder extends Emitter
 	
 	/**
 	 * Get attached track
-	 * @returns {IncomingStreamTrack} track
+	 * @returns {IncomingStreamTrack | null} track
 	 */
 	getIncomingTrack()
 	{
@@ -177,7 +189,6 @@ class Transponder extends Emitter
 	
 	/**
 	 * Get available encodings and layers
-	 * @returns {Object} 
 	 */
 	getAvailableLayers()
 	{
@@ -186,7 +197,6 @@ class Transponder extends Emitter
 
 	/**
 	 * Get available encodings and layers
-	 * @returns {Object} 
 	 */
 	async getAvailableLayersAsync()
 	{
@@ -262,10 +272,10 @@ class Transponder extends Emitter
 		let spatialLayerIdMin	= LayerInfo.MaxLayerId;
 		let temporalLayerIdMin	= LayerInfo.MaxLayerId;
 		
-		let ordering = false;
+		let ordering = /** @type {(a: LayerStats, b: LayerStats) => number} */ (/** @type {any} */ (false));
 		
 		//Helper for retrieving spatial info
-		const getSpatialLayerId = function(layer) {
+		const getSpatialLayerId = function(/** @type {LayerStats} */ layer) {
 			// Either spatialLayerId on SVC stream or simulcastIdx on simulcast stream
 			return layer.spatialLayerId!=LayerInfo.MaxLayerId ? layer.spatialLayerId : layer.simulcastIdx ;
 		};
@@ -436,10 +446,10 @@ class Transponder extends Emitter
 		let spatialLayerIdMin	= LayerInfo.MaxLayerId;
 		let temporalLayerIdMin	= LayerInfo.MaxLayerId;
 		
-		let ordering = false;
+		let ordering = /** @type {(a: LayerStats, b: LayerStats) => number} */ (/** @type {any} */ (false));
 		
 		//Helper for retrieving spatial info
-		const getSpatialLayerId = function(layer) {
+		const getSpatialLayerId = function(/** @type {LayerStats} */ layer) {
 			// Either spatialLayerId on SVC stream or simulcastIdx on simulcast stream
 			return layer.spatialLayerId!=LayerInfo.MaxLayerId ? layer.spatialLayerId : layer.simulcastIdx ;
 		};
@@ -613,10 +623,10 @@ class Transponder extends Emitter
 		this.transponder.SelectLayer(curated.spatialLayerId,curated.temporalLayerId);
 	}
 
-	/*
+	/**
 	 * Select the simulcast encoding layer
-	 * @param {String} encoding Id - rid value of the simulcast encoding of the track
-	 * @param {Boolean} smooth - Wait until next valid frame before switching to the new encoding
+	 * @param {String} encodingId - rid value of the simulcast encoding of the track
+	 * @param {Boolean} [smooth] - Wait until next valid frame before switching to the new encoding
 	 */
 	selectEncoding(encodingId,smooth) 
 	{
@@ -668,7 +678,6 @@ class Transponder extends Emitter
 
 	/**
 	 * Get current selected layer info
-	 * @returns {Object} 
 	 */
 	getSelectedLayer()
 	{
@@ -764,6 +773,7 @@ class Transponder extends Emitter
 		super.stop();
 
 		//Remove transport reference, so destructor is called on GC
+		//@ts-expect-error
 		this.transponder = null;
 		//Remove track referecne also
 		this.track = null;

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -26,9 +26,73 @@ const {
 
 const Utils		= require("./Utils");
 
+//@ts-expect-error
+const parseInt = /** @type {(x: number) => number} */ (global.parseInt);
+
 let maxId = 0;
 
 const noop = function(){};
+
+/**
+ * @typedef {"new" | "connecting" | "connected" | "closed" | "failed"} DTLSState
+ * DTLS connection state as per the w3c spec
+ */
+
+/**
+ * @typedef {Object} TransportDumpOptions
+ * @property {boolean} incoming Dump incomoning RTP data [Default: true]
+ * @property {boolean} outgoing Dump outgoing RTP data [Default: true]
+ * @property {boolean} rtcp Dump rtcp RTP data [Default: true]
+ * @property {boolean} rtpHeadersOnly Dump only rtp headers and first 16 bytes of payload for rtp packets [Default: false]
+ * @property {boolean} bwe Dump bwe stats to a different file (.pcap->.csv) [Default: true]
+ */
+
+/**
+ * @typedef {Object} TransportStats
+ * @property {number} senderSideEstimationBitrate Sender side estimation bitrate (if available)
+ * @property {number} senderSideTargetBitrate
+ * @property {ICEStats} [ice]
+ */
+
+/**
+ * @typedef {Object} ICEStats ICE related stats
+ * @property {number} requestsSent Number of ice requests sent
+ * @property {number} requestsReceived Number of ice requests received
+ * @property {number} responsesSent Number of ice responses sent
+ * @property {number} responsesReceived Number of ice responses received
+ */
+
+/**
+ * @typedef {Object} SSRCs
+ * @property {number} [media] ssrc for the media track 
+ * @property {number} [rtx] ssrc for the rtx track (only applicable to video tracks)
+ */
+
+/**
+ * @typedef {Object} CreateStreamTrackOptions
+ * @property {string} [id] Stream track id (default: "audio" for audio tracks, "video" for video tracks)
+ * @property {string} [mediaId] Stream track media id (mid)
+ * @property {SSRCs} [ssrcs] Override the generated ssrcs for this track
+ */
+
+/**
+ * @typedef {Object} CreateStreamOptions
+ * @property {string} [id]
+ * @property {Array<CreateStreamTrackOptions>|CreateStreamTrackOptions} [audio] Add audio track to the new stream
+ * @property {Array<CreateStreamTrackOptions>|CreateStreamTrackOptions} [video] Add video track to the new stream
+ */
+
+/**
+ * @typedef {Object} TransportEvents
+ * @property {(self: Transport) => void} stopped
+ * @property {(self: Transport) => void} icetimeout ICE timeout. Fired when no ICE request ar received for 30 seconds.
+ * @property {(state: DTLSState, self: Transport) => void} dtlsstate DTLS State change
+ * @property {(candidate: CandidateInfo, self: Transport) => void} remoteicecandidate ICE remote candidate activation. This event fires when ICE candidate has correctly being checked out and we start using it for sending. (`candidate` is the ip and port of the remote ICE candidate that is in use by the transport)
+ * @property {(targetBitrate: number, bandwidthEstimation: number, totalBitrate: Number, self: Transport) => void} targetbitrate Transport sender side estimation bitrate target update
+ * @property {(track: IncomingStreamTrack, stream: IncomingStream | null) => void} incomingtrack New incoming stream track added to transport
+ * @property {(track: OutgoingStreamTrack, stream: OutgoingStream | null) => void} outgoingtrack New outgoing stream track added to transport
+ * @property {(ip: string, port: number, error: any) => void} rawtxdataerror Error occurred when calling {@link setCandidateRawTxData} on behalf of the user
+ */
 
 /**
  * A transport represent a connection between a local ICE candidate and a remote set of ICE candidates over a single DTLS session.
@@ -37,6 +101,7 @@ const noop = function(){};
  * You must create the incoming streams as signaled on the remote SDP as any incoming RTP with an unknown ssrc will be ignored. 
  * When you create an outgoing stream, the transport will allocate internally the ssrcs for the different RTP streams in order to avoid collision. You will be able to retrieve that information from the streams object in order to be able to announce them on the SDP sent to the remote side.
  * In order to decide how to route your streams you must attach the outgoing streams from one transport to the incoming streams of other (or same) transport.
+ * @extends {Emitter<TransportEvents>}
  */
 class Transport extends Emitter
 {
@@ -45,7 +110,11 @@ class Transport extends Emitter
 	 * @hideconstructor
 	 * private constructor
 	 */
-	constructor(bundle, remote, local, options)
+	constructor(
+		/** @type {import("./Endpoint").NativeBundle} */ bundle,
+		/** @type {import("./Endpoint").ParsedPeerInfo} */ remote,
+		/** @type {import("./Endpoint").ParsedPeerInfo} */ local,
+		/** @type {import("./Endpoint").CreateTransportOptions} */ options)
 	{
 		//Init emitter
 		super();
@@ -56,6 +125,7 @@ class Transport extends Emitter
 			throw new Error("You must provide remote ice and dtls info");
 		
 		//Store remote properties
+		/** @type {import("./Endpoint").ParsedPeerInfo} */
 		this.remote = { ...remote, candidates: [] };
 		
 		//Create local info
@@ -93,6 +163,7 @@ class Transport extends Emitter
 		//Store bundle
 		this.bundle = bundle;
 		//No state yet
+		/** @type {DTLSState} */
 		this.dtlsState = "new";
 		//Create native onnection
 		this.connection = SharedPointer(bundle.AddICETransport(this.username,properties));
@@ -109,13 +180,17 @@ class Transport extends Emitter
 			this.emit("icetimeout", this);
 		};
 		//Event listener for dtls state changes
-		this.ondtlsstate = (state) => {
+		this.ondtlsstate = (/** @type {DTLSState} */ state) => {
 			//Store dtls state
 			this.dtlsState = state;
 			this.emit("dtlsstate",state, this);
 		};
 		//Event listener for ice candidate activation
-		this.onremoteicecandidate = (ip,port,priority) => {
+		this.onremoteicecandidate = (
+			/** @type {string} */ ip,
+			/** @type {number} */ port,
+			/** @type {number} */ priority,
+		) => {
 			this.emit("remoteicecandidate", new CandidateInfo("1", 1, "UDP", priority, ip, port, "host"), this);
 		};
 		//Craeate transport listener
@@ -124,7 +199,11 @@ class Transport extends Emitter
 		this.transport.SetListener(this.listener);
 		
 		//Event listener for sender side estimator
-		this.ontargetbitrate = (targetBitrate, bandwidthEstimation, totalBitrate)  => {
+		this.ontargetbitrate = (
+			/** @type {number} */ targetBitrate,
+			/** @type {number} */ bandwidthEstimation,
+			/** @type {number} */ totalBitrate,
+		)  => {
 			//Store sender side estimator
 			this.senderSideTargetBitrate = targetBitrate;
 			this.senderSideEstimationBitrate = bandwidthEstimation;
@@ -143,11 +222,11 @@ class Transport extends Emitter
 		this.addRemoteCandidates(remote.candidates || []);
 		
 		//List of streams
-		this.incomingStreams = new Map();
-		this.outgoingStreams = new Map();
+		this.incomingStreams = /** @type {Map<string, IncomingStream>} */ (new Map());
+		this.outgoingStreams = /** @type {Map<string, OutgoingStream>} */ (new Map());
 		//LIst of tracks
-		this.incomingStreamTracks = new Map();
-		this.outgoingStreamTracks = new Map();
+		this.incomingStreamTracks = /** @type {Map<string, IncomingStreamTrack>} */ (new Map());
+		this.outgoingStreamTracks = /** @type {Map<string, OutgoingStreamTrack>} */ (new Map());
 		
 		//Create new sequence generator
 		this.lfsr = new LFSR();
@@ -156,12 +235,7 @@ class Transport extends Emitter
 	/**
 	 * Dump incoming and outgoint rtp and rtcp packets into a pcap file
 	 * @param {String} filename - Filename of the pcap file
-	 * @param {Object} options  - Dump parameters (optional)
-	 * @param {Boolean} options.incoming   - Dump incomoning RTP data
-	 * @param {Boolean} options.outgoing  - Dump outgoing RTP data
-	 * @param {Boolean} options.rtcp      - Dump rtcp RTP data
-	 * @param {Boolean} options.rtpHeadersOnly      - Dump only rtp headers and first 16 bytes of payload for rtp packets
-	 * @param {Boolean} options.bwe      -  Dump bwe stats to a different file (.pcap->.csv)
+	 * @param {TransportDumpOptions} [options]  - Dump parameters
 	 */
 	dump(filename,options) 
 	{
@@ -196,15 +270,7 @@ class Transport extends Emitter
 	
 	/**
 	 * Get transport stats
-	 * 
-	 *  - senderSideEstimationBitrate    : Sender side estimation bitrate (if available)
-	 *  - ice      : ICE related stats
-	 *	* requestsSent		: Number of ice requests sent
-	 *	* requestsReceived	: Number of ice requests received
-	 *	* responsesSent		: Number of ice responses sent
-	 *	* responsesReceived	: Number of ice responses received
-	 *	
-	 * @return {Object} stats
+	 * @return {TransportStats} stats
 	 */
 	getStats()
 	{
@@ -222,8 +288,8 @@ class Transport extends Emitter
 
 	/**
 	 * Restart ICE on transport object
-	 * @param {Object|ICEInfo}  remoteICE	- Remote ICE info, containing the username and password.
-	 * @param {Object|ICEInfo}  localICE	- Local ICE info, containing the username and password [Optional]
+	 * @param {ICEInfo | SemanticSDP.ICEInfoPlain}  remoteICE	- Remote ICE info, containing the username and password
+	 * @param {ICEInfo | SemanticSDP.ICEInfoPlain}  [localICE]	- Local ICE info, containing the username and password
 	 * @returns {ICEInfo}	Local ICE info
 	 */
 	restartICE(remoteICE, localICE)
@@ -270,7 +336,7 @@ class Transport extends Emitter
 
 	/**
 	 * Get available outgoing bitrate in bps.
-	 * @returns {Nummber} 
+	 * @returns {Number} 
 	 */
 	getAvailableOutgoingBitrate()
 	{
@@ -279,7 +345,7 @@ class Transport extends Emitter
 
 	/**
 	 * Get bandwidth estimation in bps.
-	 * @returns {Nummber} 
+	 * @returns {Number} 
 	 */
 	getEstimatedBitrate()
 	{
@@ -288,7 +354,7 @@ class Transport extends Emitter
 
 	/**
 	 * Get current sent bitrate
-	 * @returns {Nummber} 
+	 * @returns {Number} 
 	 */
 	getTotalSentBitrate()
 	{
@@ -300,7 +366,7 @@ class Transport extends Emitter
 	 * This will send padding only RTX packets to allow bandwidth estimation algortithm to probe bitrate beyonf current sent values.
 	 * The ammoung of probing bitrate would be limited by the sender bitrate estimation and the limit set on the setMaxProbing Bitrate.
 	 * Note that this will only work on browsers that supports RTX and transport wide cc.
-	 * @param {Boolen} probe
+	 * @param {boolean} probe
 	 */
 	setBandwidthProbing(probe)
 	{
@@ -357,9 +423,7 @@ class Transport extends Emitter
 	
 	/**
 	 * Set local RTP properties 
-	 * @param {Object|SDPInfo} rtp - Object param containing media information for audio and video
-	 * @param {MediaInfo} rtp.audio	- Audio media info
-	 * @param {MediaInfo} rtp.video	- Video media info
+	 * @param {Utils.RTPProperties | SDPInfo} rtp
 	 */
 	setLocalProperties(rtp)
 	{
@@ -374,9 +438,7 @@ class Transport extends Emitter
 	
 	/**
 	 * Set remote RTP properties 
-	 * @param {Object|SDPInfo} rtp - Object param containing media information for audio and video
-	 * @param {MediaInfo} rtp.audio	- Audio media info
-	 * @param {MediaInfo} rtp.video	- Video media info
+	 * @param {Utils.RTPProperties | SDPInfo} rtp
 	 */
 	setRemoteProperties(rtp)
 	{
@@ -411,7 +473,7 @@ class Transport extends Emitter
 	
 	/**
 	 * Get current dtls state for transport
-	 * @returns {String} DTLS connection state as per the w3c spec  "new", "connecting", "connected", "closed", "failed"
+	 * @returns {DTLSState}
 	 */
 	getDTLSState()
 	{
@@ -438,7 +500,7 @@ class Transport extends Emitter
 
 	/**
 	 * Get local ICE candidates for this transport
-	 * @returns {Array.CandidateInfo}
+	 * @returns {Array<CandidateInfo>}
 	 */
 	getLocalCandidates() 
 	{
@@ -466,7 +528,7 @@ class Transport extends Emitter
 
 	/**
 	 * Get remote ICE candidates for this transport
-	 * @returns {Array.CandidateInfo}
+	 * @returns {Array<CandidateInfo>}
 	 */
 	getRemoteCandidates() 
 	{
@@ -485,7 +547,10 @@ class Transport extends Emitter
 		if (candidate.getTransport().toLowerCase()!="udp")
 			return false;
 
-		let ip,port;
+		/** @type {string} */
+		let ip;
+		/** @type {number} */
+		let port;
 		
 		//If it is a relay candidate
 		if ("relay"===candidate.getType())
@@ -517,7 +582,7 @@ class Transport extends Emitter
 		return true;
 	}
 
-	async setCandidateRawTxData(ip, port)
+	async setCandidateRawTxData(/** @type {string} */ ip, /** @type {number} */ port)
 	{
 		const ifindex = this.bundle.rawTxInterface;
 		if (ifindex === undefined)
@@ -532,7 +597,7 @@ class Transport extends Emitter
 	
 	/**
 	 * Register an array remote candidate info. Only needed for ice-lite to ice-lite endpoints
-	 * @param {Array.CandidateInfo} candidates
+	 * @param {Array<CandidateInfo>} candidates
 	 */
 	addRemoteCandidates(candidates)
 	{
@@ -544,18 +609,18 @@ class Transport extends Emitter
 	
 	/**
 	 * Create new outgoing stream in this transport
-	 * @param {Object|StreamInfo|String} params Params plain object, StreamInfo object or stream id
-	 * @param {Array<Object>|Object|boolean} params.audio	- Add audio track to the new stream
-	 * @param {Array<Object>|Object|boolean} params.video	- Add video track to the new stream
+	 * @param {CreateStreamOptions|StreamInfo|String} params Params plain object, StreamInfo object or stream id
 	 * @returns {OutgoingStream} The new outgoing stream
 	 */
 	createOutgoingStream(params) 
 	{
+		/** @type {StreamInfo} */
 		let info;
 		//Generate the stream info from paramss
 		if (params && params.constructor.name === "StreamInfo")
 		{
 			//Clone it
+			//@ts-expect-error
 			info = params.clone();
 		} else if (typeof params === 'string') {
 			//Param is the media id
@@ -567,6 +632,9 @@ class Transport extends Emitter
 			//Generate ramdon
 			info = new StreamInfo(uuidV4());
 		}
+
+		// from here on, we can assume `params` holds the plain object
+		params = /** @type {CreateStreamOptions} */ (params);
 		
 		//IF we already have that id
 		if (this.incomingStreams.has(info.getId()))
@@ -664,8 +732,8 @@ class Transport extends Emitter
 	
 	/**
 	 * Create new outgoing stream in this transport
-	 * @param {String}  media		- Track media type "audio" or "video"
-	 * @param {Object?} params		- Track parameters
+	 * @param {"audio" | "video"} media Track media type
+	 * @param {CreateStreamTrackOptions} [params] Track parameters
 	 * @returns {OutgoingStreamTrack} The new outgoing stream track
 	 */
 	createOutgoingStreamTrack(media, params)
@@ -678,7 +746,7 @@ class Transport extends Emitter
 			throw new Error("Incorrect media type");
 	
 		//Get media type and id
-		const type	= (media==="audio") ? 0 : 1;
+		const type	= /** @type {Native.MediaFrameType} */ (media==="audio" ? 0 : 1);
 		const id	= opts.id || (media + (maxId++));
 		const mediaId	= String(opts.mediaId || "");
 		
@@ -723,7 +791,7 @@ class Transport extends Emitter
 	
 	/**
 	 * Create an incoming stream object from the media stream info objet
-	 * @param {StreamInfo|Object|String} info Contains the ids and ssrcs of the stream to be created
+	 * @param {StreamInfo|SemanticSDP.StreamInfoPlain|String} info Contains the ids and ssrcs of the stream to be created, or a plain stream id
 	 * @returns {IncomingStream} The newly created incoming stream object
 	 */
 	createIncomingStream(info)
@@ -737,7 +805,9 @@ class Transport extends Emitter
 			};
 
 		//IF we already have that id
-		if (this.incomingStreams.has(info.getId ? info.getId() : info.id))
+		//@ts-expect-error
+		const requestedId = info.getId ? info.getId() : info.id;
+		if (this.incomingStreams.has(requestedId))
 			//Launch exception
 			throw new Error("Duplicated stream id");
 		
@@ -771,7 +841,7 @@ class Transport extends Emitter
 	
 	/**
 	 * Get all the incoming streams in the transport
-	 * @returns {Array<IncomingStreams>}
+	 * @returns {IncomingStream[]}
 	 */
 	getIncomingStreams()
 	{
@@ -781,7 +851,7 @@ class Transport extends Emitter
 	/**
 	 * Get incoming stream
 	 * @param {String} streamId the stream ID
-	 * @returns {IncomingStream}
+	 * @returns {IncomingStream | undefined}
 	 */
 	getIncomingStream(streamId)
 	{
@@ -791,7 +861,7 @@ class Transport extends Emitter
 	
 	/**
 	 * Get all the outgoing streams in the transport
-	 * @returns {Array<OutgoingStreams>}
+	 * @returns {OutgoingStream[]}
 	 */
 	getOutgoingStreams()
 	{
@@ -801,7 +871,7 @@ class Transport extends Emitter
 	/**
 	 * Get outgoing stream
 	 * @param {String} streamId the stream ID
-	 * @returns {OutgoingStream}
+	 * @returns {OutgoingStream | undefined}
 	 */
 	getOutgoingStream(streamId)
 	{
@@ -811,8 +881,8 @@ class Transport extends Emitter
 	
 	/**
 	 * Create new incoming stream in this transport. TODO: Simulcast is still not supported
-	 * @param {String}  media		- Track media type "audio" or "video"
-	 * @param {Object?} params		- Track parameters
+	 * @param {"audio" | "video"} media Track media type
+	 * @param {CreateStreamTrackOptions} [params] Track parameters
 	 * @returns {IncomingStreamTrack} The new incoming stream track
 	 */
 	createIncomingStreamTrack(media, params)
@@ -820,7 +890,7 @@ class Transport extends Emitter
 		const opts = params || {};
 	
 		//Get media type and id
-		const type	= (media==="audio") ? 0 : 1;
+		const type	= /** @type {Native.MediaFrameType} */ ((media==="audio") ? 0 : 1);
 		const id	= opts.id || (media + (maxId++));
 		const mediaId	= String(opts.mediaId || "");
 
@@ -842,6 +912,7 @@ class Transport extends Emitter
 			throw new Error("Could not add incoming source group to native transport");
 		
 		//Create source map
+		/** @type {IncomingStreamTrack.NativeSourceMap} */
 		const sources = {"":source};
 
 		//Create new track
@@ -942,11 +1013,17 @@ class Transport extends Emitter
 		super.stop();
 
 		//Remove transport reference, so destructor is called on GC
+		//@ts-expect-error
 		this.username = null;
+		//@ts-expect-error
 		this.connection = null;
+		//@ts-expect-error
 		this.transport = null;
+		//@ts-expect-error
 		this.senderSideListener = null;
+		//@ts-expect-error
 		this.listener = null;
+		//@ts-expect-error
 		this.bundle = null;
 	}
 }

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -197,7 +197,7 @@ class Transport extends Emitter
 	/**
 	 * Get transport stats
 	 * 
-	 *  - senderSideEstimationBitrate    : Sneder side estimation bitrate (if available)
+	 *  - senderSideEstimationBitrate    : Sender side estimation bitrate (if available)
 	 *  - ice      : ICE related stats
 	 *	* requestsSent		: Number of ice requests sent
 	 *	* requestsReceived	: Number of ice requests received
@@ -546,15 +546,7 @@ class Transport extends Emitter
 	 * Create new outgoing stream in this transport
 	 * @param {Object|StreamInfo|String} params Params plain object, StreamInfo object or stream id
 	 * @param {Array<Object>|Object|boolean} params.audio	- Add audio track to the new stream
-	 * @param {Object?} params.id	- Stream id, an UUID will be generated if not provided
-	 * @param {Object?} params.audio.id	- Stream track id (default: "audio")
-	 * @param {Number?} params.audio.ssrcs	- Override the generated ssrcs for this track
-	 * @param {Number?} params.audio.ssrcs.media - ssrc for the audio track
 	 * @param {Array<Object>|Object|boolean} params.video	- Add video track to the new stream
-	 * @param {Object?} params.video.id	- Stream track id (default: "video")
-	 * @param {Object?} params.video.ssrcs	- Override the generated ssrcs for this track
-	 * @param {Number?} params.video.ssrcs.media	- ssrc for the video track
-	 * @param {Number?} params.video.ssrcs.rtx 	- ssrc for the rtx video track
 	 * @returns {OutgoingStream} The new outgoing stream
 	 */
 	createOutgoingStream(params) 
@@ -674,11 +666,6 @@ class Transport extends Emitter
 	 * Create new outgoing stream in this transport
 	 * @param {String}  media		- Track media type "audio" or "video"
 	 * @param {Object?} params		- Track parameters
-	 * @param {Object?} params.id		- Stream track id
-	 * @param {Object?} params.mediaId	- Stream track media id (mid)
-	 * @param {Number?} params.ssrcs	- Override the generated ssrcs for this track
-	 * @param {Number?} params.ssrcs.media	- ssrc for the media track
-	 * @param {Number?} params.ssrcs.rtx 	- ssrc for the rtx track
 	 * @returns {OutgoingStreamTrack} The new outgoing stream track
 	 */
 	createOutgoingStreamTrack(media, params)
@@ -812,9 +799,9 @@ class Transport extends Emitter
 	}
 	
 	/**
-	 * Get incoming stream
+	 * Get outgoing stream
 	 * @param {String} streamId the stream ID
-	 * @returns {IncomingStream}
+	 * @returns {OutgoingStream}
 	 */
 	getOutgoingStream(streamId)
 	{
@@ -826,11 +813,6 @@ class Transport extends Emitter
 	 * Create new incoming stream in this transport. TODO: Simulcast is still not supported
 	 * @param {String}  media		- Track media type "audio" or "video"
 	 * @param {Object?} params		- Track parameters
-	 * @param {Object?} params.id		- Stream track id
-	 * @param {Object?} params.mediaId	- Stream track media id (mid)
-	 * @param {Number?} params.ssrcs	- Override the generated ssrcs for this track
-	 * @param {Number?} params.ssrcs.media	- ssrc for the media track
-	 * @param {Number?} params.ssrcs.rtx 	- ssrc for the rtx track
 	 * @returns {IncomingStreamTrack} The new incoming stream track
 	 */
 	createIncomingStreamTrack(media, params)

--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -5,11 +5,18 @@ const {
 } = require("semantic-sdp");
 
 
-function ensureString(str)
+function ensureString(/** @type {string} */ str)
 {
 	return "string" === typeof str ? str : String(str);
 }
-function convertRTPProperties(rtp)
+
+/**
+ * @typedef {Object} RTPProperties Object param containing media information for audio and video
+ * @property {MediaInfo | SemanticSDP.MediaInfoPlain} [audio]
+ * @property {MediaInfo | SemanticSDP.MediaInfoPlain} [video]
+ */
+
+function convertRTPProperties(/** @type {RTPProperties} */ rtp)
 {
 	//Create new native properties object
 	let properties = new Native.Properties();


### PR DESCRIPTION
finally, after #216 I think I have everything ready to add / fix the JSDoc comments on the code.
I'm pretty happy with the results, very very few errors remain ^^
and I found many typos along the way (#215)

the rationale is the same than for https://github.com/medooze/semantic-sdp-js/pull/28. our current typings are so outdated they're likely misleading people at this point rather than helping. so, delete them and autogenerate them from the JSDoc comments in our code.

**not ready for review yet.** there are still some things I'd like to take out of this PR first, to ease review (a bugfix and some needed refactors)