### PR TITLE
remove jsdoc event blocks

### DIFF
--- a/lib/ActiveSpeakerDetector.js
+++ b/lib/ActiveSpeakerDetector.js
@@ -24,14 +24,6 @@ class ActiveSpeakerDetector extends Emitter
 		
 		//Listen for speaker changes		
 		this.onactivespeakerchanged = (id) => {
-			/**
-			* ActiveSpeakerDetector new active speaker detected event
-			*
-			* @name activespeakerchanged
-			* @memberof ActiveSpeakerDetector
-			* @kind event
-			* @argument {IncomingStreamTrack} track - Track that has been activated
-			*/
 			//Get track
 			const track = this.tracks.get(id);
 			//Prevent race condition
@@ -167,14 +159,6 @@ class ActiveSpeakerDetector extends Emitter
 			//remove track
 			this.removeSpeaker (track);
 	
-		/**
-		* ActiveSpeakerDetector stopped event
-		*
-		* @name stopped
-		* @memberof ActiveSpeakerDetector
-		* @kind event
-		* @argument {ActiveSpeakerDetector} activeSpeakerDetector
-		*/
 		this.emit("stopped");
 
 		//Stop emitter

--- a/lib/ActiveSpeakerMultiplexer.js
+++ b/lib/ActiveSpeakerMultiplexer.js
@@ -24,15 +24,6 @@ class ActiveSpeakerMultiplexer extends Emitter
 		
 		//Listen for speaker changes		
 		this.onactivespeakerchanged = (speakerId,multiplexeId) => {
-			/**
-			* ActiveSpeakerMultiplexer new active speaker detected event
-			*
-			* @name activespeakerchanged
-			* @memberof ActiveSpeakerMultiplexer
-			* @kind event
-			* @argument {IncomingStreamTrack} incomingStreamTrack - Track that has been voice activated
-		        * @argument {IncomingStreamTrack} outgoingStreamTrack - Track that has been multiplexed into
-			*/
 			//Get speaker track
 			const incomingStreamTrack	= this.speakers.get(speakerId);
 			const outgoingStreamTrack	= this.multiplex.get(multiplexeId).outgoingTrack;
@@ -42,14 +33,6 @@ class ActiveSpeakerMultiplexer extends Emitter
 				this.emit("activespeakerchanged",incomingStreamTrack,outgoingStreamTrack);
 		};
 		this.onactivespeakerremoved = (multiplexeId) => {
-			/**
-			* ActiveSpeakerMultiplexer active speaker removed event
-			*
-			* @name noactivespeaker
-			* @memberof ActiveSpeakerMultiplexer
-			* @kind event
-		        * @argument {IncomingStreamTrack} outgoingStreamTrack - Track with no active speaker
-			*/
 			//Get multiplexed track
 			const outgoingStreamTrack	= this.multiplex.get(multiplexeId).outgoingTrack;
 			//Prevent race condition
@@ -254,14 +237,6 @@ class ActiveSpeakerMultiplexer extends Emitter
 			//Remove it
 			this.removeSpeaker(track) 
 
-		/**
-		* ActiveSpeakerMultiplexer stopped event
-		*
-		* @name stopped
-		* @memberof ActiveSpeakerMultiplexer
-		* @kind event
-		* @argument {ActiveSpeakerMultiplexer} ActiveSpeakerMultiplexer
-		*/
 		this.emit("stopped");
 
 		//Stop multiplexer

--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -458,14 +458,6 @@ class Endpoint extends Emitter
 			//Stop it
 			mirror.stop();
 		
-		/**
-		* Endpoint stopped event
-		*
-		* @name stopped
-		* @memberof Endpoint
-		* @kind event
-		* @argument {Endpoint} endpoint
-		*/
 		this.emit("stopped",this);
 		
 		//End bundle

--- a/lib/IncomingStream.js
+++ b/lib/IncomingStream.js
@@ -156,14 +156,6 @@ class IncomingStream extends Emitter
 		{
 			//Store it
 			this.muted = muting;
-			/**
-			* IncomingStream stopped event
-			*
-			* @name muted
-			* @memberof IncomingStream
-			* @kind event
-			* @argument {boolean} muted
-			*/
 			this.emit("muted",this.muted);
 		}
 	}
@@ -249,14 +241,6 @@ class IncomingStream extends Emitter
 
 			//If it is the first
 			if (this.counter===1)
-				/**
-				* IncomingStream attached event
-				*
-				* @name attached
-				* @memberof IncomingStream
-				* @kind event
-				* @argument {IncomingStream} incomingStream
-				*/
 				this.emit("attached",this);
 		}
 
@@ -268,14 +252,6 @@ class IncomingStream extends Emitter
 
 				//If it is the first
 				if (this.counter===1)
-					/**
-					* IncomingStream attached event
-					*
-					* @name attached
-					* @memberof IncomingStream
-					* @kind event
-					* @argument {IncomingStream} incomingStream
-					*/
 					this.emit("attached",this);
 			})
 			.on("detached",()=>{
@@ -284,14 +260,6 @@ class IncomingStream extends Emitter
 
 				//If it is the last
 				if (this.counter===0)
-					/**
-					* IncomingStream detached event
-					*
-					* @name detached
-					* @memberof IncomingStream
-					* @kind event
-					* @argument {IncomingStream} incomingStream
-					*/
 					this.emit("detached",this);
 			});
 
@@ -303,15 +271,6 @@ class IncomingStream extends Emitter
 		//Add it to map
 		this.tracks.set(incomingStreamTrack.getId(),incomingStreamTrack);
 
-		/**
-		* IncomingStreamTrack added to stream
-		*
-		* @name track
-		* @memberof IncomingStream
-		* @kind event
-	        * @argument {IncomingStream} incomingStream
-		* @argument {IncomingStreamTrack} incomingStreamTrack
-		*/
 		!this.stopped && this.emit("track",this,incomingStreamTrack);
 	}
 	
@@ -545,15 +504,6 @@ class IncomingStream extends Emitter
 		//Clear tracks jic
 		this.tracks.clear();
 		
-		/**
-		* IncomingStream stopped event
-		*
-		* @name stopped
-		* @memberof IncomingStream
-		* @kind event
-		* @argument {IncomingStream} incomingStream
-		* @argument {Objects} last stats before closing
-		*/
 		this.emit("stopped",this,stats);
 		
 		//Stop emitter

--- a/lib/IncomingStreamTrack.js
+++ b/lib/IncomingStreamTrack.js
@@ -661,14 +661,6 @@ class IncomingStreamTrack extends Emitter
 		
 		//If it is the first
 		if (this.counter===1)
-			/**
-			* IncomingStreamTrack attached event
-			*
-			* @name attached
-			* @memberof IncomingStreamTrack
-			* @kind event
-			* @argument {IncomingStreamTrack} incomingStreamTrack
-			*/
 			this.emit("attached",this);
 	}
 	
@@ -725,14 +717,6 @@ class IncomingStreamTrack extends Emitter
 		{
 			//Store it
 			this.muted = muting;
-			/**
-			* IncomingStreamTrack stopped event
-			*
-			* @name muted
-			* @memberof OutgoingStreamTrack
-			* @kind event
-			* @argument {boolean} muted
-			*/
 			this.emit("muted",this.muted);
 		}
 	}
@@ -757,14 +741,6 @@ class IncomingStreamTrack extends Emitter
 		
 		//If it is the last
 		if (this.counter===0)
-			/**
-			* IncomingStreamTrack detached event
-			*
-			* @name detached
-			* @memberof IncomingStreamTrack
-			* @kind event
-			* @argument {IncomingStreamTrack} incomingStreamTrack
-			*/
 			this.emit("detached",this);
 	}
 	
@@ -845,14 +821,6 @@ class IncomingStreamTrack extends Emitter
 		//Stop global depacketizer
 		if (this.depacketizer) this.depacketizer.Stop();
 		
-		/**
-		* IncomingStreamTrack stopped event
-		*
-		* @name stopped
-		* @memberof IncomingStreamTrack
-		* @kind event
-		* @argument {IncomingStreamTrack} incomingStreamTrack
-		*/
 		this.emit("stopped",this,this.stats);
 		
 		//Stop emitter

--- a/lib/IncomingStreamTrackMirrored.js
+++ b/lib/IncomingStreamTrackMirrored.js
@@ -69,15 +69,6 @@ class IncomingStreamTrackMirrored extends Emitter
 			//Push new encoding
 			this.encodings.set(mirrored.id, mirrored);
 
-			/**
-			* IncomingStreamTrack new encoding event
-			*
-			* @name encoding
-			* @memberof IncomingStreamTrack
-			* @kind event
-			* @argument {IncomingStreamTrack} incomingStreamTrack
-		        * @argument {Object} encoding
-			*/
 			this.emit("encoding",this,mirrored);
 		}
 
@@ -236,14 +227,6 @@ class IncomingStreamTrackMirrored extends Emitter
 		
 		//If it is the first
 		if (this.counter===1)
-			/**
-			* IncomingStreamTrackMirrored attached event
-			*
-			* @name attached
-			* @memberof IncomingStreamTrackMirrored
-			* @kind event
-			* @argument {IncomingStreamTrackMirrored} incomingStreamTrack
-			*/
 			this.emit("attached",this);
 	}
 	
@@ -275,14 +258,6 @@ class IncomingStreamTrackMirrored extends Emitter
 		
 		//If it is the last
 		if (this.counter===0)
-			/**
-			* IncomingStreamTrackMirrored dettached event
-			*
-			* @name detached
-			* @memberof IncomingStreamTrackMirrored
-			* @kind event
-			* @argument {IncomingStreamTrackMirrored} incomingStreamTrack
-			*/
 			this.emit("detached",this);
 	}
 
@@ -317,14 +292,6 @@ class IncomingStreamTrackMirrored extends Emitter
 		{
 			//Store it
 			this.muted = muting;
-			/**
-			* IncomingStreamTrack stopped event
-			*
-			* @name muted
-			* @memberof OutgoingStreamTrack
-			* @kind event
-			* @argument {boolean} muted
-			*/
 			this.emit("muted",this.muted);
 		}
 	}
@@ -349,14 +316,6 @@ class IncomingStreamTrackMirrored extends Emitter
 			encoding.depacketizer.Stop();
 		}
 
-		/**
-		* IncomingStreamTrack stopped event
-		*
-		* @name stopped
-		* @memberof IncomingStreamTrackMirrored
-		* @kind event
-		* @argument {IncomingStreamTrackMirrored} incomingStreamTrack
-		*/
 		this.emit("stopped",this);
 		
 		//remove encpodings

--- a/lib/IncomingStreamTrackReader.js
+++ b/lib/IncomingStreamTrackReader.js
@@ -39,15 +39,6 @@ class IncomingStreamTrackReader extends Emitter
 		};
 		//Frame listener
 		this.onframe = (buffer,type,codec) => {
-			/**
-			* AudioDecoder stopped event
-			*
-			* @name stopped
-			* @memberof IncomingStreamTrackReader
-			* @kind event
-		        * @argument {Object} frame
-			* @argument {IncomingStreamTrackReader} reader
-			*/
 			this.emit("frame", {buffer,type,codec}, this);
 			//Reset refresher interval
 			this.refresher?.restart(this.minPeriod);
@@ -112,14 +103,6 @@ class IncomingStreamTrackReader extends Emitter
 		//Stop refresher
 		this.refresher?.stop();
 
-		/**
-		* AudioDecoder stopped event
-		*
-		* @name stopped
-		* @memberof IncomingStreamTrackReader
-		* @kind event
-		* @argument {IncomingStreamTrackReader} reader
-		*/
 		this.emit("stopped", this);
 		
 		//Stop emitter

--- a/lib/IncomingStreamTrackSimulcastAdapter.js
+++ b/lib/IncomingStreamTrackSimulcastAdapter.js
@@ -458,14 +458,6 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 		{
 			//Store it
 			this.muted = muting;
-			/**
-			* IncomingStreamTrack stopped event
-			*
-			* @name muted
-			* @memberof OutgoingStreamTrack
-			* @kind event
-			* @argument {boolean} muted
-			*/
 			this.emit("muted",this.muted);
 		}
 	}
@@ -498,14 +490,6 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 		
 		//If it is the first
 		if (this.counter===1)
-			/**
-			* IncomingStreamTrackMirrored attached event
-			*
-			* @name attached
-			* @memberof IncomingStreamTrackMirrored
-			* @kind event
-			* @argument {IncomingStreamTrackMirrored} incomingStreamTrack
-			*/
 			this.emit("attached",this);
 	}
 	
@@ -539,14 +523,6 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 		
 		//If it is the last
 		if (this.counter===0)
-			/**
-			* IncomingStreamTrackMirrored dettached event
-			*
-			* @name detached
-			* @memberof IncomingStreamTrackMirrored
-			* @kind event
-			* @argument {IncomingStreamTrackMirrored} incomingStreamTrack
-			*/
 			this.emit("detached",this);
 	}
 	
@@ -584,14 +560,6 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 		//Stop global depacketizer
 		if (this.depacketizer) this.depacketizer.Stop();
 
-		/**
-		* IncomingStreamTrack stopped event
-		*
-		* @name stopped
-		* @memberof IncomingStreamTrackMirrored
-		* @kind event
-		* @argument {IncomingStreamTrackMirrored} incomingStreamTrack
-		*/
 		this.emit("stopped",this);
 		
 		//Stop emitter

--- a/lib/OutgoingStream.js
+++ b/lib/OutgoingStream.js
@@ -129,14 +129,6 @@ class OutgoingStream extends Emitter
 		{
 			//Store it
 			this.muted = muting;
-			/**
-			* OutgoingStreamTrack stopped event
-			*
-			* @name muted
-			* @memberof OutgoingStream
-			* @kind event
-			* @argument {boolean} muted
-			*/
 			this.emit("muted",this.muted);
 		}
 	}
@@ -394,14 +386,6 @@ class OutgoingStream extends Emitter
 		//Add it to map
 		this.tracks.set(trackId,outgoingStreamTrack);
 		
-		/**
-		* OutgingStreamTrack created
-		*
-		* @name track
-		* @memberof OutgoingStream
-		* @kind event
-		* @argument {OutgingStreamTrack} outgoingStreamTrack
-		*/
 		!this.stopped && this.emit("track",outgoingStreamTrack);
 		
 		//Done
@@ -427,15 +411,6 @@ class OutgoingStream extends Emitter
 		//Clear tracks jic
 		this.tracks.clear();
 		
-		/**
-		* OutgoingStream stopped event
-		*
-		* @name stopped
-		* @memberof OutgoingStream
-		* @kind event
-		* @argument {OutgoingStream} outgoingStream
-		* @argument {Objects} last stats before closing
-		*/
 		this.emit("stopped",this,stats);
 		
 		//Stop emitter

--- a/lib/OutgoingStreamTrack.js
+++ b/lib/OutgoingStreamTrack.js
@@ -99,15 +99,6 @@ class OutgoingStreamTrack extends Emitter
 
 		//Native REMB event
 		this.onremb = (bitrate) => {
-			/**
-			* OutgoingStreamTrack remb event
-			*
-			* @name remb
-			* @memberof OutgoingStreamTrack
-			* @kind event
-			* @argument {OutgoingStreamTrack} outgoingStreamTrack
-			* @argument {Number} bitrate estimation
-			*/
 			this.emit("remb",bitrate,this);
 		};
 	}
@@ -288,14 +279,6 @@ class OutgoingStreamTrack extends Emitter
 		{
 			//Store it
 			this.muted = muting;
-			/**
-			* OutgoingStreamTrack stopped event
-			*
-			* @name muted
-			* @memberof OutgoingStreamTrack
-			* @kind event
-			* @argument {boolean} muted
-			*/
 			this.emit("muted",this.muted);
 		}
 	}
@@ -423,14 +406,6 @@ class OutgoingStreamTrack extends Emitter
 		//Stop listening for events, as they might have been queued
 		this.onremb = ()=>{};
 		
-		/**
-		* OutgoingStreamTrack stopped event
-		*
-		* @name stopped
-		* @memberof OutgoingStreamTrack
-		* @kind event
-		* @argument {OutgoingStreamTrack} outgoingStreamTrack
-		*/
 		this.emit("stopped",this, this.stats);
 		
 		//Stop emitter

--- a/lib/PeerConnectionServer.js
+++ b/lib/PeerConnectionServer.js
@@ -179,14 +179,6 @@ class PeerConnectionServer extends Emitter
 						capabilities	: this.capabilities
 					});
 					
-					/**
-					* New managed transport has been created by a remote peer connection client
-					*
-					* @name transport
-					* @memberof PeerConnectionServer
-					* @kind event
-					* @argument {Transport}  transport An initialized transport
-					*/
 					this.emit("transport",transport);
 					
 					break;
@@ -221,14 +213,6 @@ class PeerConnectionServer extends Emitter
 		//Close ns
 		this.ns.close();
 		
-		/**
-		* PeerConnectionServer stopped event
-		* 
-		* @name stopped
-		* @memberof PeerConnectionServer
-		* @kind event
-		* @argument {PeerConnectionServer}  peerConnectionServer
-		*/
 		this.emit("stopped",this);
 		
 		//Stop emitter

--- a/lib/Player.js
+++ b/lib/Player.js
@@ -96,14 +96,6 @@ class Player extends Emitter
 				return;
 			}
 			
-			/**
-			* Playback ended event
-			*
-			* @name ended
-			* @memberof Player
-			* @kind event
-			* @argument {Player}  player
-			*/
 			this.emit("ended",this);
 		};
 	}
@@ -210,14 +202,6 @@ class Player extends Emitter
 		//Close
 		this.player.Close();
 		
-		/**
-		* Player stopped event
-		* 
-		* @name stopped
-		* @memberof Player
-		* @kind event
-		* @argument {Player}  player
-		*/
 		this.emit("stopped",this);
 
 		//Stop emitter

--- a/lib/Recorder.js
+++ b/lib/Recorder.js
@@ -60,15 +60,6 @@ class Recorder extends Emitter
 		
 		//Listener for player facade events
 		this.onstarted = (timestamp) => {
-			/**
-			* Recorder started event. This event will be triggered when the first media frame is being recorded.
-			*
-			* @name started
-			* @memberof Recorder
-			* @kind event
-			* @argument {Recorder}  recorder
-			* @argument {Number}  timestamp - Timestamp of the first frame in milliseconds
-			*/
 			this.emit("started",this,timestamp);
 		};
 	}
@@ -246,14 +237,6 @@ class Recorder extends Emitter
 			this.recorder.Close();
 		});
 		
-		/**
-		* Recorder stopped event
-		*
-		* @name stopped
-		* @memberof Recorder
-		* @kind event
-		* @argument {Recorder}  recorder
-		*/
 		this.emit("stopped",this);
 
 		//Stop emitter

--- a/lib/RecorderTrack.js
+++ b/lib/RecorderTrack.js
@@ -87,14 +87,6 @@ class RecorderTrack extends Emitter
 			//Store it
 			this.muted = muting;
 			
-			/**
-			* Transponder muted event
-			*
-			* @name muted
-			* @memberof Transponder
-			* @kind event
-			* @argument {Transponder}  transponder
-			*/
 			this.emit("muted",this.muted);
 		}
 	}
@@ -113,14 +105,6 @@ class RecorderTrack extends Emitter
 		//Remove listener
 		this.track.off("stopped",this.onTrackStopped);
 		
-		/**
-		* RecorderTrack stopped event
-		*
-		* @name stopped
-		* @memberof RecorderTrack
-		* @kind event
-		* @argument {RecorderTrack}  recorderTrack
-		*/
 		this.emit("stopped",this);
 		
 		//Stop emitter

--- a/lib/Refresher.js
+++ b/lib/Refresher.js
@@ -39,14 +39,6 @@ class Refresher extends Emitter
 		clearInterval(this.interval);
 		//Start the refresh interval
 		this.interval = setInterval(()=>{
-			/**
-			* Refresher event to indicate that refesh is taking place
-			*
-			* @name refreshing
-			* @memberof Refresher
-			* @kind event
-			* @argument {Refresher}  refreser
-			*/
 			//Emit event
 			this.emit("refreshing",this);
 			//For each track on set
@@ -121,14 +113,6 @@ class Refresher extends Emitter
 			//Remove stop edevent
 			track.off("stopped",this.ontrackstopped);
 		
-		/**
-		* Refresher stopped event
-		* 
-		* @name stopped
-		* @memberof Refresher
-		* @kind event
-		* @argument {Refresher}  refresher
-		*/
 		this.emit("stopped",this);
 		
 		//Stop emitter

--- a/lib/SDPManager.js
+++ b/lib/SDPManager.js
@@ -54,14 +54,6 @@ class SDPManager extends Emitter
 	 */
 	stop()
 	{
-		/**
-		* SDPManager stopped event
-		*
-		* @name stopped
-		* @memberof SDPManager
-		* @kind event
-		* @argument {SDPManager}  transport
-		*/
 		this.emit("stopped",this);
 	
 		//Stop emitter

--- a/lib/Transponder.js
+++ b/lib/Transponder.js
@@ -219,14 +219,6 @@ class Transponder extends Emitter
 			//Call native transponder
 			this.transponder && this.transponder.Mute(muting);
 			
-			/**
-			* Transponder muted event
-			*
-			* @name muted
-			* @memberof Transponder
-			* @kind event
-			* @argument {Transponder}  transponder
-			*/
 			this.emit("muted",this.muted);
 		}
 	}
@@ -766,14 +758,6 @@ class Transponder extends Emitter
 		//Stop it
 		this.transponder.Close();
 		
-		/**
-		* Transponder stopped event
-		*
-		* @name stopped
-		* @memberof Transponder
-		* @kind event
-		* @argument {Transponder}  transponder
-		*/
 		this.emit("stopped",this);
 		
 		//Stop emitter

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -104,43 +104,16 @@ class Transport extends Emitter
 
 		//Event listener for ice timoute
 		this.onicetimeout = () => {
-			/**
-			* ICE timoute event. Fired when no ICE request ar received for 30 seconds.
-			*
-			* @name icetimeout
-			* @memberof Transport
-			* @kind event
-			* @argument {Transport} transport
-			*/
 			this.emit("icetimeout", this);
 		};
 		//Event listener for dtls state changes
 		this.ondtlsstate = (state) => {
 			//Store dtls state
 			this.dtlsState = state;
-			/**
-			* DTLS State change event
-			*
-			* @name dtlsstate
-			* @memberof Transport
-			* @kind event
-			* @argument {String} dtlsstate DTLS connection state as per the w3c spec  "new", "connecting", "connected", "closed", "failed"
-			* @argument {Transport} transport
-			*/
 			this.emit("dtlsstate",state, this);
 		};
 		//Event listener for ice candidate activation
 		this.onremoteicecandidate = (ip,port,priority) => {
-			/**
-			* ICE remote candidate activation event.
-			* This event fires when ICE candidate has correctly being checked out and we start using it for sending.
-			*
-			* @name remoteicecandidate
-			* @memberof Transport
-			* @kind event
-			* @argument {CandidateInfo} candidate  The ip and port of the remote ICE candidate that is in use by the transport
-			* @argument {Transport} transport
-			*/
 			this.emit("remoteicecandidate", new CandidateInfo("1", 1, "UDP", priority, ip, port, "host"), this);
 		};
 		//Craeate transport listener
@@ -153,17 +126,6 @@ class Transport extends Emitter
 			//Store sender side estimator
 			this.senderSideTargetBitrate = targetBitrate;
 			this.senderSideEstimationBitrate = bandwidthEstimation;
-			/**
-			* Transport sender side estimation bitrate target udpate
-			*
-			* @name targetbitrate
-			* @memberof Transport
-			* @kind event
-			* @argument {Integer} targetBitrate
-		        * @argument {Integer} bandwidthEstimation
-		        * @argument {Integer} totalBitrate
-			* @argument {Transport} transport
-			*/
 			this.emit("targetbitrate",targetBitrate,bandwidthEstimation,totalBitrate,this);
 		};
 		//Create native listener
@@ -764,15 +726,6 @@ class Transport extends Emitter
 		//Add to the track list
 		this.outgoingStreamTracks.set(outgoingStreamTrack.getId(),outgoingStreamTrack);
 		
-		/**
-		* New outgoing stream track added to transport
-		*
-		* @name outgoingtrack
-		* @memberof Transport
-		* @kind event
-		* @argument {OutgoingStreamTrack} track
-		* @argument {OutgoingStream?} stream
-		*/
 		this.emit("outgoingtrack",outgoingStreamTrack,null);
 			
 		//Return it
@@ -923,15 +876,6 @@ class Transport extends Emitter
 		//Add to the track list
 		this.incomingStreamTracks.set(incomingStreamTrack.getId(),incomingStreamTrack);
 		
-		/**
-		* New incoming stream track added to transport
-		*
-		* @name incomingtrack
-		* @memberof Transport
-		* @kind event
-		* @argument {IncomingStreamTrack} track
-		* @argument {IncomingStream} stream 
-		*/
 		this.emit("incomingtrack",incomingStreamTrack,null);
 			
 		//Return it
@@ -1008,14 +952,6 @@ class Transport extends Emitter
 		//No state yet
 		this.dtlsState = "closed";
 		
-		/**
-		* Transport stopped event
-		*
-		* @name stopped
-		* @memberof Transport
-		* @kind event
-		* @argument {Transport}  transport
-		*/
 		this.emit("stopped",this);
 		
 		//Stop emitter


### PR DESCRIPTION
this is what we did in https://github.com/medooze/srt-server-node/pull/43#issuecomment-1723112825.
when we add type annotations (#217) these event blocks are converted to a central `@typedef` at the top of the file, i.e:

https://github.com/medooze/media-server-node/blob/fae10185b2f9e664c06c7b039a0dfb0a0e1033ee/lib/Transport.js#L63-L73

i would like to delete the jsdoc blocks because:
 - many of them are outdated or just incorrect
 - i'd prefer having a single source of truth
 - the new syntax is more compact, yet allows expressing the same info
 - the new syntax is actually **enforced** by typechecking, which ensures we'll keep it up to date, and it also helps users
 - in the future we can switch to [typedoc](https://typedoc.org) to render our documentation, and it will make this info visible again.
   (we already use typedoc in nal-extractor, if you want to see [an example](https://medooze.github.io/nal-extractor/main/classes/sync_MetadataSync.SimpleMetadataSync.html))