### PR TITLE
reintroduce SharedPointer calls

### DIFF
--- a/lib/IncomingStream.js
+++ b/lib/IncomingStream.js
@@ -353,7 +353,7 @@ class IncomingStream extends Emitter
 					for (let j=0; j<encodings[i].length; ++j)
 					{
 						//Create single incoming source
-						const source = new Native.RTPIncomingSourceGroupShared(type,this.transport.GetTimeService());
+						const source = SharedPointer(new Native.RTPIncomingSourceGroupShared(type,this.transport.GetTimeService()));
 
 						//Set mid
 						const mid = trackInfo.getMediaId();
@@ -417,7 +417,7 @@ class IncomingStream extends Emitter
 				for (let i=0; i<ssrcs.length; ++i)
 				{
 					//Create single incoming source
-					const source = new Native.RTPIncomingSourceGroupShared(type,this.transport.GetTimeService());
+					const source = SharedPointer(new Native.RTPIncomingSourceGroupShared(type,this.transport.GetTimeService()));
 
 					//Set source data
 					source.media.ssrc = ssrcs[i];
@@ -448,7 +448,7 @@ class IncomingStream extends Emitter
 				}
 			} else {
 				//Create single incoming source
-				const source = new Native.RTPIncomingSourceGroupShared(type,this.transport.GetTimeService());
+				const source = SharedPointer(new Native.RTPIncomingSourceGroupShared(type,this.transport.GetTimeService()));
 
 				//If we had ssrc info
 				if (trackInfo.getSSRCs().length)

--- a/lib/IncomingStreamTrack.js
+++ b/lib/IncomingStreamTrack.js
@@ -327,7 +327,7 @@ class IncomingStreamTrack extends Emitter
 		//If multiple sources and got time service
 		if (num > 1 && timeService)
 			//Create a simulcast frame listerner
-			this.depacketizer = new Native.SimulcastMediaFrameListenerShared(timeService, 1, num);
+			this.depacketizer = SharedPointer(new Native.SimulcastMediaFrameListenerShared(timeService, 1, num));
 		
 		//For each source
 		for (let id of Object.keys(sources))
@@ -340,7 +340,7 @@ class IncomingStreamTrack extends Emitter
 				id		: id,
 				source		: source,
 				receiver	: receiver,
-				depacketizer	: new Native.RTPIncomingMediaStreamDepacketizerShared(source.toRTPIncomingMediaStream())
+				depacketizer	: SharedPointer(new Native.RTPIncomingMediaStreamDepacketizerShared(source.toRTPIncomingMediaStream()))
 			};
 			
 			//Push new encoding

--- a/lib/IncomingStreamTrackMirrored.js
+++ b/lib/IncomingStreamTrackMirrored.js
@@ -55,7 +55,7 @@ class IncomingStreamTrackMirrored extends Emitter
 			}
 
 			//Create mirrored source
-			const source = new Native.RTPIncomingMediaStreamMultiplexerShared(encoding.source.toRTPIncomingMediaStream(), timeService);
+			const source = SharedPointer(new Native.RTPIncomingMediaStreamMultiplexerShared(encoding.source.toRTPIncomingMediaStream(), timeService));
 
 			//Get mirror encoding
 			const mirrored = {
@@ -63,7 +63,7 @@ class IncomingStreamTrackMirrored extends Emitter
 				source		: source,
 				mirror		: encoding.source,
 				receiver	: encoding.receiver,
-				depacketizer	: new Native.RTPIncomingMediaStreamDepacketizerShared(source.toRTPIncomingMediaStream())
+				depacketizer	: SharedPointer(new Native.RTPIncomingMediaStreamDepacketizerShared(source.toRTPIncomingMediaStream()))
 			};
 
 			//Push new encoding

--- a/lib/IncomingStreamTrackReader.js
+++ b/lib/IncomingStreamTrackReader.js
@@ -1,6 +1,7 @@
 const Native		= require("./Native");
 const Emitter		= require("medooze-event-emitter");
 const Refresher		= require("./Refresher")
+const SharedPointer	= require("./SharedPointer");
 
 class IncomingStreamTrackReader extends Emitter
 {
@@ -17,7 +18,7 @@ class IncomingStreamTrackReader extends Emitter
 		this.intraOnly = intraOnly;
 		this.minPeriod = minPeriod;
 		//Create decoder
-		this.reader = new Native.MediaFrameReaderShared(this,intraOnly,minPeriod,!!ondemand);
+		this.reader = SharedPointer(new Native.MediaFrameReaderShared(this,intraOnly,minPeriod,!!ondemand));
 
 		//Check if we need to create a refresher for requesting intra periodically
 		if (this.minPeriod>0)

--- a/lib/IncomingStreamTrackSimulcastAdapter.js
+++ b/lib/IncomingStreamTrackSimulcastAdapter.js
@@ -1,6 +1,7 @@
 const Native		= require("./Native");
 const Emitter		= require("medooze-event-emitter");
 const LayerInfo		= require("./LayerInfo");
+const SharedPointer	= require("./SharedPointer");
 const SemanticSDP	= require("semantic-sdp");
 const SDPInfo		= SemanticSDP.SDPInfo;
 const Setup		= SemanticSDP.Setup;
@@ -150,7 +151,7 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 		this.encodingPerTrack = new Map();
 
 		//Create a simulcast frame listerner
-		this.depacketizer = new Native.SimulcastMediaFrameListenerShared(timeService, 1, 0);
+		this.depacketizer = SharedPointer(new Native.SimulcastMediaFrameListenerShared(timeService, 1, 0));
 		
 		//On stopped listener
 		this.onstopped = (incomingStreamTrack) => {

--- a/lib/OutgoingStream.js
+++ b/lib/OutgoingStream.js
@@ -333,7 +333,7 @@ class OutgoingStream extends Emitter
 		const mediaId = String((params.constructor.name === "TrackInfo" ? params.getMediaId() : params && params.mediaId ? params.mediaId : "") || "");
 		
 		//Create incoming track
-		const source = new Native.RTPOutgoingSourceGroupShared(mediaId, type, this.transport.GetTimeService());
+		const source = SharedPointer(new Native.RTPOutgoingSourceGroupShared(mediaId, type, this.transport.GetTimeService()));
 		
 		//The list of streams
 		if (params.constructor.name === "TrackInfo")

--- a/lib/Recorder.js
+++ b/lib/Recorder.js
@@ -3,6 +3,7 @@ const Emitter		= require("medooze-event-emitter");
 const IncomingStream    = require("./IncomingStream");
 const RecorderTrack	= require("./RecorderTrack");
 const Refresher		= require("./Refresher");
+const SharedPointer	= require("./SharedPointer");
 /**
  * MP4 recorder that allows to record several streams/tracks on a single mp4 file
  */
@@ -30,7 +31,7 @@ class Recorder extends Emitter
 		this.filename = filename;
 	
 		//Create native recorder
-		this.recorder = new Native.MP4RecorderFacadeShared(this);
+		this.recorder = SharedPointer(new Native.MP4RecorderFacadeShared(this));
 		
 		//Check if not doing a time shifted recording
 		if (!this.params.timeShift)

--- a/lib/SharedPointer.js
+++ b/lib/SharedPointer.js
@@ -41,6 +41,9 @@ class Handler
 
 function SharedPointer(obj, cache)
 {
+	//If what we get passed is already a proxy, return it unchanged
+	if (obj[SharedPointer.Target])
+		return obj;
 	//If we already have a proxy for that object
 	if (cache && cache.has(obj))
 		//Return 

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -95,7 +95,7 @@ class Transport extends Emitter
 		//Create native onnection
 		this.connection = SharedPointer(bundle.AddICETransport(this.username,properties));
 		//Get transport
-		this.transport = this.connection.transport;
+		this.transport = SharedPointer(this.connection.transport);
 
 		//If overriding the bwe
 		if (!!options.overrideBWE)
@@ -737,7 +737,7 @@ class Transport extends Emitter
 			throw new Error("Duplicated stream id");
 		
 		//Create incoming track
-		const source = new Native.RTPOutgoingSourceGroupShared(mediaId,type,this.transport.GetTimeService());
+		const source = SharedPointer(new Native.RTPOutgoingSourceGroupShared(mediaId,type,this.transport.GetTimeService()));
 		//Set source ssrcs
 		source.media.ssrc	= opts.ssrcs ? opts.ssrcs.media : this.lfsr.seq(31);
 		if (media=="video")
@@ -800,7 +800,7 @@ class Transport extends Emitter
 			throw new Error("Duplicated stream id");
 		
 		//We have to add the incmoing source for this stream
-		let incomingStream = new IncomingStream(this.transport,this.transport.toRTPReceiver(),info);
+		let incomingStream = new IncomingStream(this.transport,SharedPointer(this.transport.toRTPReceiver()),info);
 		
 		//Add to list
 		this.incomingStreams.set(incomingStream.getId(),incomingStream);
@@ -893,7 +893,7 @@ class Transport extends Emitter
 			throw new Error("Duplicated track id");
 		
 		//Create incoming track
-		const source = new Native.RTPIncomingSourceGroupShared(type,this.transport.GetTimeService());
+		const source = SharedPointer(new Native.RTPIncomingSourceGroupShared(type,this.transport.GetTimeService()));
 
 		//Set source ssrcs
 		source.media.ssrc	= opts.ssrcs ? opts.ssrcs.media : this.lfsr.seq(31);
@@ -908,7 +908,7 @@ class Transport extends Emitter
 		const sources = {"":source};
 
 		//Create new track
-		const incomingStreamTrack = new IncomingStreamTrack(media,id,mediaId,this.transport.GetTimeService(),this.transport.toRTPReceiver(),sources);
+		const incomingStreamTrack = new IncomingStreamTrack(media,id,mediaId,this.transport.GetTimeService(),SharedPointer(this.transport.toRTPReceiver()),sources);
 
 		//Add listener
 		incomingStreamTrack.once("stopped",()=>{


### PR DESCRIPTION
SharedPointer has an automagical system that wraps most native functions in a proxy that does `SharedPointer()` for you.

This is nice, but for now it's hard to make the type system aware of this, so I'd like to reintroduce the calls to SharedPointer even if they don't do anything (consider them annotations like #217).