### PR TITLE
deduplicate SemanticSDP parsing

### DIFF
--- a/lib/EmulatedTransport.js
+++ b/lib/EmulatedTransport.js
@@ -61,10 +61,7 @@ class EmulatedTransport extends Emitter
 	setRemoteProperties(rtp)
 	{
 		//Get native properties
-		let properties = Utils.convertRTPProperties(rtp.constructor.name ==="SDPInfo" ? {
-				"audio" : rtp.getMedia("audio"),
-				"video" : rtp.getMedia("video")
-			} : rtp);
+		let properties = Utils.convertRTPProperties(Utils.parseRTPProperties(rtp));
 		//Set it
 		this.transport.SetRemoteProperties(properties);
 	}

--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -8,6 +8,7 @@ const SDPManagerPlanB			= require("./SDPManagerPlanB");
 const IncomingStream			= require("./IncomingStream");
 const IncomingStreamTrackMirrored	= require("./IncomingStreamTrackMirrored");
 const ActiveSpeakerMultiplexer		= require("./ActiveSpeakerMultiplexer");
+const Utils				= require("./Utils");
 	
 const SemanticSDP	= require("semantic-sdp");
 const SDPInfo		= SemanticSDP.SDPInfo;
@@ -195,15 +196,15 @@ class Endpoint extends Emitter
 		
 		//Create remote properites
 		const remote = {
-			dtls		: remoteInfo.dtls.constructor.name === "DTLSInfo" ? remoteInfo.dtls.clone() : DTLSInfo.expand(remoteInfo.dtls),
-			ice		: remoteInfo.ice .constructor.name === "ICEInfo"  ? remoteInfo.ice.clone()  : ICEInfo.expand(remoteInfo.ice),
+			dtls		: Utils.parseDTLSInfo(remoteInfo.dtls, true),
+			ice		: Utils.parseICEInfo(remoteInfo.ice, true),
 			candidates	: []
 		};
 		
 		//Add all remote candidates
 		for (let i=0;remoteInfo.candidates && i<remoteInfo.candidates.length; ++i)
 			//Clone
-			remote.candidates.push(remoteInfo.candidates[i].constructor.name === "CandidateInfo"? remoteInfo.candidates[i].clone() : CandidateInfo.expand(remoteInfo.candidates[i]));
+			remote.candidates.push(Utils.parseCandidateInfo(remoteInfo.candidates[i], true));
 
 		//If there is no local info
 		if (!localInfo)
@@ -227,15 +228,15 @@ class Endpoint extends Emitter
 		
 		//Create local properites
 		const local = {
-			dtls		: localInfo.dtls.constructor.name === "DTLSInfo" ? localInfo.dtls.clone() : DTLSInfo.expand(localInfo.dtls),
-			ice		: localInfo.ice.constructor.name === "ICEInfo"  ? localInfo.ice.clone()  : ICEInfo.expand(localInfo.ice),
+			dtls		: Utils.parseDTLSInfo(localInfo.dtls, true),
+			ice		: Utils.parseICEInfo(localInfo.ice, true),
 			candidates	: []
 		};
 		
 		//Add all local candidates
 		for (let i=0;localInfo.candidates && i<localInfo.candidates.length; ++i)
 			//Clone
-			local.candidates.push(localInfo.candidates[i].constructor.name === "CandidateInfo" ? localInfo.candidates[i].clone() : CandidateInfo.expand(localInfo.candidates[i]));
+			local.candidates.push(Utils.parseCandidateInfo(localInfo.candidates[i], true));
 		
 		//Set lite nd end of candidates to ICE info
 		local.ice.setLite(true);

--- a/lib/IncomingStream.js
+++ b/lib/IncomingStream.js
@@ -1,5 +1,6 @@
 const Native		= require("./Native");
 const SharedPointer	= require("./SharedPointer");
+const Utils 		= require("./Utils");
 const Emitter	= require("medooze-event-emitter");
 const SemanticSDP	= require("semantic-sdp");
 const IncomingStreamTrack	= require("./IncomingStreamTrack");
@@ -29,7 +30,7 @@ class IncomingStream extends Emitter
 		super();
 
 		//Store stream info
-		const streamInfo = info.constructor.name === "StreamInfo" ? info.clone() : StreamInfo.expand(info);
+		const streamInfo = Utils.parseStreamInfo(info, true);
 		
 		//Store id
 		this.id = streamInfo.getId();

--- a/lib/OutgoingStream.js
+++ b/lib/OutgoingStream.js
@@ -1,5 +1,6 @@
 const Native			= require("./Native");
 const SharedPointer		= require("./SharedPointer");
+const Utils			= require("./Utils");
 const Emitter		= require("medooze-event-emitter");
 const SemanticSDP		= require("semantic-sdp");
 const OutgoingStreamTrack	= require("./OutgoingStreamTrack");
@@ -30,7 +31,7 @@ class OutgoingStream extends Emitter
 		super();
 
 		//Store stream info
-		this.info = info.constructor.name === "StreamInfo" ? info.clone() : StreamInfo.expand(info);
+		this.info = Utils.parseStreamInfo(info, true);
 		
 		//Store id
 		this.id		= this.info.getId();

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -258,24 +258,21 @@ class Transport extends Emitter
 
 	/**
 	 * Restart ICE on transport object
-	 * @param {Object|ICEInfo}  remoteICE	- Remote ICE info, containing the username and password.
-	 * @param {Object|ICEInfo}  localICE	- Local ICE info, containing the username and password [Optional]
+	 * @param {Object|ICEInfo}  remoteICE_	- Remote ICE info, containing the username and password.
+	 * @param {Object|ICEInfo}  localICE_	- Local ICE info, containing the username and password [Optional]
 	 * @returns {ICEInfo}	Local ICE info
 	 */
-	restartICE(remoteICE, localICE)
+	restartICE(remoteICE_, localICE_)
 	{
 		//Support both plain js object and SDPInfo
-		if (remoteICE.constructor.name !== "ICEInfo")
-			//Convert
-			remoteICE = ICEInfo.expand(remoteICE)
+		const remoteICE = Utils.parseICEInfo(remoteICE_, false);
 
 		//If there is no local info
-		if (!localICE)
+		const localICE = !localICE_ ?
 			//Generate one
-			localICE = ICEInfo.generate(true)
-		else if (localICE.constructor.name !== "ICEInfo") 
-			//localICE
-			localInfo = ICEInfo.expand(localInfo)
+			ICEInfo.generate(true) :
+			//Otherwise use the supplied one
+			Utils.parseICEInfo(localICE_, false);
 
 		//Create new native properties object
 		const properties = new Native.Properties();
@@ -400,10 +397,7 @@ class Transport extends Emitter
 	setLocalProperties(rtp)
 	{
 		//Get native properties
-		let properties = Utils.convertRTPProperties(rtp.constructor.name ==="SDPInfo" ? {
-				"audio" : rtp.getMedia("audio"),
-				"video" : rtp.getMedia("video")
-			} : rtp);
+		let properties = Utils.convertRTPProperties(Utils.parseRTPProperties(rtp));
 		//Set it
 		this.transport.SetLocalProperties(properties);
 	}
@@ -416,18 +410,14 @@ class Transport extends Emitter
 	 */
 	setRemoteProperties(rtp)
 	{
+		const parsed = Utils.parseRTPProperties(rtp);
 		//Get native properties
-		let properties = Utils.convertRTPProperties(rtp.constructor.name ==="SDPInfo" ? {
-				"audio" : rtp.getMedia("audio"),
-				"video" : rtp.getMedia("video")
-			} : rtp);
-		//Get audio
-		const audio = rtp.constructor.name ==="SDPInfo" ? rtp.getMedia("audio") : rtp.audio;
+		let properties = Utils.convertRTPProperties(parsed);
 		//Check if remote audio supports rtx
-		if (audio)
+		if (parsed.audio)
 		{
 			//Supppor plain and Semantic SDP objects
-			const audioInfo = audio.constructor.name === "MediaInfo" ? audio : MediaInfo.expand(audio);
+			const audioInfo = Utils.parseMediaInfo(parsed.audio, false);
 			//Check all codecs
 			for (const [type,codec] of audioInfo.getCodecs())
 			{

--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -1,12 +1,67 @@
 const Native		= require("./Native");
 const SemanticSDP	= require("semantic-sdp");
-const MediaInfo		= SemanticSDP.MediaInfo;
+const {
+	MediaInfo,
+	CodecInfo,
+	TrackInfo,
+	StreamInfo,
+	DTLSInfo,
+	ICEInfo,
+	CandidateInfo,
+} = require("semantic-sdp");
 
+function parseMediaInfo(/** @type {MediaInfo | SemanticSDP.MediaInfoPlain} */ info, /** @type {boolean} */ clone) {
+	//@ts-expect-error
+	return /** @type {MediaInfo} */ (info.constructor.name === "MediaInfo" ? (clone ? info.clone() : info) : MediaInfo.expand(info));
+}
+function parseCodecInfo(/** @type {CodecInfo | SemanticSDP.CodecInfoPlain} */ info, /** @type {boolean} */ clone) {
+	//@ts-expect-error
+	return /** @type {CodecInfo} */ (info.constructor.name === "CodecInfo" ? (clone ? info.clone() : info) : CodecInfo.expand(info));
+}
+function parseTrackInfo(/** @type {TrackInfo | SemanticSDP.TrackInfoPlain} */ info, /** @type {boolean} */ clone) {
+	//@ts-expect-error
+	return /** @type {TrackInfo} */ (info.constructor.name === "TrackInfo" ? (clone ? info.clone() : info) : TrackInfo.expand(info));
+}
+function parseStreamInfo(/** @type {StreamInfo | SemanticSDP.StreamInfoPlain} */ info, /** @type {boolean} */ clone) {
+	//@ts-expect-error
+	return /** @type {StreamInfo} */ (info.constructor.name === "StreamInfo" ? (clone ? info.clone() : info) : StreamInfo.expand(info));
+}
+function parseDTLSInfo(/** @type {DTLSInfo | SemanticSDP.DTLSInfoPlain} */ info, /** @type {boolean} */ clone) {
+	//@ts-expect-error
+	return /** @type {DTLSInfo} */ (info.constructor.name === "DTLSInfo" ? (clone ? info.clone() : info) : DTLSInfo.expand(info));
+}
+function parseICEInfo(/** @type {ICEInfo | SemanticSDP.ICEInfoPlain} */ info, /** @type {boolean} */ clone) {
+	//@ts-expect-error
+	return /** @type {ICEInfo} */ (info.constructor.name === "ICEInfo" ? (clone ? info.clone() : info) : ICEInfo.expand(info));
+}
+function parseCandidateInfo(/** @type {CandidateInfo | SemanticSDP.CandidateInfoPlain} */ info, /** @type {boolean} */ clone) {
+	//@ts-expect-error
+	return /** @type {CandidateInfo} */ (info.constructor.name === "CandidateInfo" ? (clone ? info.clone() : info) : CandidateInfo.expand(info));
+}
+
+
+//@ts-expect-error
+const parseInt = /** @type {(x: number) => number} */ (global.parseInt);
 
 function ensureString(str)
 {
 	return "string" === typeof str ? str : String(str);
 }
+
+/** @returns {RTPProperties} */
+function parseRTPProperties(/** @type {RTPProperties | SemanticSDP.SDPInfo} */ rtp)
+{
+	if (rtp.constructor.name === "SDPInfo")
+	{
+		rtp = /** @type {SemanticSDP.SDPInfo} */ (rtp);
+		return {
+			"audio" : rtp.getMedia("audio"),
+			"video" : rtp.getMedia("video"),
+		};
+	}
+	return /** @type {RTPProperties} */ (rtp);
+}
+
 function convertRTPProperties(rtp)
 {
 	//Create new native properties object
@@ -18,7 +73,7 @@ function convertRTPProperties(rtp)
 		let num = 0;
 		
 		//Supppor plain and Semantic SDP objects
-		const audio = rtp.audio.constructor.name === "MediaInfo" ? rtp.audio : MediaInfo.expand(rtp.audio);
+		const audio = parseMediaInfo(rtp.audio, false);
 
 		//For each codec
 		for (let codec of audio.getCodecs().values())
@@ -59,7 +114,7 @@ function convertRTPProperties(rtp)
 	{
 		let num = 0;
 		//Supppor plain and Semantic SDP objects
-		const video = rtp.video.constructor.name === "MediaInfo" ? rtp.video : MediaInfo.expand(rtp.video);
+		const video = parseMediaInfo(rtp.video, false);
 		//For each codec
 		for (let codec of video.getCodecs().values())
 		{
@@ -98,5 +153,13 @@ function convertRTPProperties(rtp)
 };
 
 module.exports = {
+	parseMediaInfo,
+	parseCodecInfo,
+	parseTrackInfo,
+	parseStreamInfo,
+	parseDTLSInfo,
+	parseICEInfo,
+	parseCandidateInfo,
+	parseRTPProperties,
 	convertRTPProperties : convertRTPProperties
 };


### PR DESCRIPTION
we have copypasted this pattern (or variations of it) throughout the code:

~~~ js
thing = thing.constructor.name === "MediaInfo" ? thing.clone() : MediaInfo.expand(thing);
~~~

to parse `thing` into a SemanticSDP object, or clone it if already parsed.

This PR extracts this pattern into functions at `Utils`. It simplifies the code and satisfies the type checker.