### PR TITLE
deduplicate parsing PeerInfo

### DIFF
--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -53,6 +53,38 @@ const parseInt = /** @type {(x: number) => number} */ (global.parseInt);
  * @property {SemanticSDP.CandidateInfo[]} candidates
  */
 
+/** @returns {ParsedPeerInfo} */
+function parsePeerInfo(/** @type {PeerInfo | SemanticSDP.SDPInfo} */ info)
+{
+	/** @type {PeerInfo} */
+	let peerInfo;
+
+	//Support both plain js object and SDPInfo
+	if (info.constructor.name === "SDPInfo") {
+		const sdpInfo = /** @type {SemanticSDP.SDPInfo} */ (info);
+		//Convert
+		peerInfo = {
+			dtls		: sdpInfo.getDTLS(),
+			ice		: sdpInfo.getICE(),
+			candidates	: sdpInfo.getCandidates()
+		};
+	} else {
+		peerInfo = /** @type {PeerInfo} */ (info);
+	}
+
+	//Ensure that we have the correct params
+	if (!info || !info.ice || !info.dtls)
+		//Error
+		throw new Error("No ICE or DTLS info provided");
+	
+	//Create remote properites
+	return {
+		dtls		: DTLSInfo.clone(peerInfo.dtls),
+		ice		: ICEInfo.clone(peerInfo.ice),
+		candidates	: (peerInfo.candidates || []).map(CandidateInfo.clone),
+	};
+}
+
 /**
  * @typedef {Object} RawTxOptions
  * @property {string} interfaceName    (required) name of interface to send on
@@ -222,53 +254,14 @@ class Endpoint extends Emitter
 			//Error
 			throw new Error("Endpoint is alredy stopped, cannot create transport");
 		
-		//Support both plain js object and SDPInfo
-		if (remoteInfo.constructor.name === "SDPInfo")
-			//Convert
-			remoteInfo = {
-				dtls		: remoteInfo.getDTLS(),
-				ice		: remoteInfo.getICE(),
-				candidates	: remoteInfo.getCandidates()
-			};
+		const remote = parsePeerInfo(remoteInfo);
 		
-		//Ensure that we have the correct params
-		if (!remoteInfo || !remoteInfo.ice || !remoteInfo.dtls)
-			//Error
-			throw new Error("No remote ICE or DTLS info provided");
-		
-		//Create remote properites
-		const remote = {
-			dtls		: DTLSInfo.clone(remoteInfo.dtls),
-			ice		: ICEInfo.clone(remoteInfo.ice),
-			candidates	: (remoteInfo.candidates || []).map(CandidateInfo.clone),
-		};
-
-		//If there is no local info
-		if (!localInfo)
-		{
-			//Generate one
-			localInfo = {
-				ice		: ICEInfo.generate(true),
-				dtls		: new DTLSInfo(Setup.reverse(remoteInfo.dtls.getSetup(),  options?.prefferDTLSSetupActive), "sha-256", this.fingerprint),
-				candidates	: this.candidates
-			};
-		//If it is an SDPInfo object
-		} else if (localInfo.constructor.name === "SDPInfo") {
-			//Convert
-			localInfo = {
-				dtls		: localInfo.getDTLS(),
-				ice		: localInfo.getICE(),
-				candidates	: localInfo.getCandidates()
-			};
-		} 
-		
-		
-		//Create local properites
-		const local = {
-			dtls		: DTLSInfo.clone(localInfo.dtls),
-			ice		: ICEInfo.clone(localInfo.ice),
-			candidates	: (localInfo.candidates || []).map(CandidateInfo.clone),
-		};
+		//If there is no local info, generate one
+		const local = parsePeerInfo(localInfo || {
+			ice		: ICEInfo.generate(true),
+			dtls		: new DTLSInfo(Setup.reverse(remote.dtls.getSetup(),  options?.prefferDTLSSetupActive), "sha-256", this.fingerprint),
+			candidates	: this.candidates
+		});
 		
 		//Set lite nd end of candidates to ICE info
 		local.ice.setLite(true);


### PR DESCRIPTION
the code to parse a PeerInfo into a ParsedPeerInfo is copy-pasted 2 times.

this also fixes the type errors.