### PR TITLE
Fix available layers stats when VLA is used with a single/default layer

### DIFF
--- a/lib/IncomingStreamTrack.js
+++ b/lib/IncomingStreamTrack.js
@@ -57,6 +57,10 @@ const {
  * @property {number} [frameCaptureDelayMax] Max bewtween local reception time and sender capture one (Absolute capture time must be negotiated)
  * @property {number} [width] video width
  * @property {number} [height] video height
+ * @property {number} [targetBitrate] signaled target bitrate on the VideoLayersAllocation header
+ * @property {number} [targetWidth] signaled target width on the VideoLayersAllocation header
+ * @property {number} [targetHeight] signaled target height on the VideoLayersAllocation header
+ * @property {number} [targetFps] signaled target fps on the VideoLayersAllocation header
  * @property {LayerStats[]} layers Information about each spatial/temporal layer (if present).
  * @property {LayerStats[]} [individual] Information about each individual layer
  */
@@ -84,6 +88,10 @@ const {
  * @property {number} [lostPacketsRatio] Lost packets ratio
  * @property {number} [width] video width
  * @property {number} [height] video height
+ * @property {number} [targetBitrate] signaled target bitrate on the VideoLayersAllocation header
+ * @property {number} [targetWidth] signaled target width on the VideoLayersAllocation header
+ * @property {number} [targetHeight] signaled target height on the VideoLayersAllocation header
+ * @property {number} [targetFps] signaled target fps on the VideoLayersAllocation header
  *
  * Info accumulated for `media` and `rtx` streams:
  *
@@ -113,6 +121,10 @@ const {
  * @property {LayerStats[]} layers
  * @property {number} [width]
  * @property {number} [height]
+ * @property {number} [targetBitrate] signaled target bitrate on the VideoLayersAllocation header
+ * @property {number} [targetWidth] signaled target width on the VideoLayersAllocation header
+ * @property {number} [targetHeight] signaled target height on the VideoLayersAllocation header
+ * @property {number} [targetFps] signaled target fps on the VideoLayersAllocation header
  */
 
 /**
@@ -161,6 +173,15 @@ function getEncodingStats(/** @type {Encoding} */ encoding)
 		encodingStats.width  = mediaStats.width;
 		encodingStats.height = mediaStats.height;
 	}
+	//Add optional attributes
+	if (mediaStats.targetBitrate>0)
+		mediaStats.targetBitrate = mediaStats.targetBitrate;
+	if (mediaStats.targetWidth>0)
+		mediaStats.targetWidth	 = mediaStats.targetWidth;
+	if (mediaStats.targetHeight>0)
+		mediaStats.targetHeight	 = mediaStats.targetHeight;
+	if (mediaStats.targetFps>0)
+		mediaStats.targetFps	 = mediaStats.targetFps;
 
 	//Done
 	return encodingStats;
@@ -202,6 +223,16 @@ function getStatsFromIncomingSource(/** @type {Native.RTPIncomingSource} */ sour
 		stats.width = source.width;
 		stats.height = source.height;
 	}
+
+	//Add optional attributes
+	if (source.targetBitrate>0)
+		stats.targetBitrate	=  source.targetBitrate;
+	if (source.targetWidth>0)
+		stats.targetWidth	=  source.targetWidth;
+	if (source.targetHeight>0)
+		stats.targetHeight	=  source.targetHeight;
+	if (source.targetFps>0)
+		stats.targetFps	= source.targetFps;
 	
 	//Get layers
 	const layers = source.layers();
@@ -227,13 +258,13 @@ function getStatsFromIncomingSource(/** @type {Native.RTPIncomingSource} */ sour
 			simulcastIdx: -1,
 		}
 		//Add optional attributes
-		if (layer.targetBitrate>=0)
+		if (layer.targetBitrate>0)
 			curated.targetBitrate	=  layer.targetBitrate;
-		if (layer.targetWidth>=0)
+		if (layer.targetWidth>0)
 			curated.targetWidth	=  layer.targetWidth;
-		if (layer.targetHeight>=0)
+		if (layer.targetHeight>0)
 			curated.targetHeight	=  layer.targetHeight;
-		if (layer.targetFps>=0)
+		if (layer.targetFps>0)
 			curated.targetFps	= layer.targetFps;
 
 		//Push layyer stats
@@ -345,12 +376,22 @@ function getActiveLayersFromStats(/** @type {TrackStats} */ stats)
 			layers		: []
 		};
 
+		//Add optional attributes
+		if (stats[id].media.targetBitrate>0)
+			encoding.targetBitrate	=  stats[id].media.targetBitrate;
+		if (stats[id].media.targetWidth>0)
+			encoding.targetWidth	=  stats[id].media.targetWidth;
+		if (stats[id].media.targetHeight>0)
+			encoding.targetHeight	=  stats[id].media.targetHeight;
+		if (stats[id].media.targetFps>0)
+			encoding.targetFps	= stats[id].media.targetFps;
+
 		//Check if we have width and height
 		if (stats[id].media.width && stats[id].media.height)
 		{
 			//Set them
-			encoding.width = stats[id].width;
-			encoding.height = stats[id].height;
+			encoding.width = stats[id].media.width;
+			encoding.height = stats[id].media.height;
 		}
 			
 		//Get layers
@@ -397,13 +438,17 @@ function getActiveLayersFromStats(/** @type {TrackStats} */ stats)
 				simulcastIdx	: encoding.simulcastIdx,
 				spatialLayerId	: LayerInfo.MaxLayerId,
 				temporalLayerId	: LayerInfo.MaxLayerId,
-				bitrate		: encoding.bitrate
+				bitrate		: encoding.bitrate,
+				targetBitrate	: encoding.targetBitrate,
+				targetWidth	: encoding.targetWidth,
+				targetHeight	: encoding.targetHeight,
+				targetFps	: encoding.targetFps
 			});
 				
 		//Add to encoding list
 		active.push(encoding);
 	}
-		
+			
 	//Return ordered info
 	return {
 		active		: active.sort((a, b) => b.bitrate - a.bitrate),

--- a/src/RTPIncomingSource.i
+++ b/src/RTPIncomingSource.i
@@ -40,5 +40,15 @@ struct RTPIncomingSource : public RTPSource
 				layers.push_back(&(it->second));
 			return layers;
 		}
+		const int64_t targetBitrate;
+		const int64_t targetWidth;
+		const int64_t targetHeight;
+		const int64_t targetFps;
 	}
 };
+%{
+int64_t RTPIncomingSource_targetBitrate_get(RTPIncomingSource* self)	{ return self->value_or(0); } 
+int64_t RTPIncomingSource_targetWidth_get(RTPIncomingSource* self)	{ return self->value_or(0); }  
+int64_t RTPIncomingSource_targetHeight_get(RTPIncomingSource* self)	{ return self->value_or(0); } 
+int64_t RTPIncomingSource_targetFps_get(RTPIncomingSource* self)	{ return self->value_or(0); }  
+%}

--- a/src/RTPIncomingSource.i
+++ b/src/RTPIncomingSource.i
@@ -47,8 +47,8 @@ struct RTPIncomingSource : public RTPSource
 	}
 };
 %{
-int64_t RTPIncomingSource_targetBitrate_get(RTPIncomingSource* self)	{ return self->value_or(0); } 
-int64_t RTPIncomingSource_targetWidth_get(RTPIncomingSource* self)	{ return self->value_or(0); }  
-int64_t RTPIncomingSource_targetHeight_get(RTPIncomingSource* self)	{ return self->value_or(0); } 
-int64_t RTPIncomingSource_targetFps_get(RTPIncomingSource* self)	{ return self->value_or(0); }  
+int64_t RTPIncomingSource_targetBitrate_get(RTPIncomingSource* self)	{ return self->targetBitrate.value_or(0); } 
+int64_t RTPIncomingSource_targetWidth_get(RTPIncomingSource* self)	{ return self->targetWidth.value_or(0); }  
+int64_t RTPIncomingSource_targetHeight_get(RTPIncomingSource* self)	{ return self->targetHeight.value_or(0); } 
+int64_t RTPIncomingSource_targetFps_get(RTPIncomingSource* self)	{ return self->targetFps.value_or(0); }  
 %}

--- a/src/RTPSource.i
+++ b/src/RTPSource.i
@@ -31,10 +31,10 @@ struct LayerSource : public LayerInfo
 	}
 };
 %{
-int64_t LayerSource_targetBitrate_get(LayerSource* self)	{ return self->targetBitrate.has_value()	? self->targetBitrate.value()	: -1; } 
-int64_t LayerSource_targetWidth_get(LayerSource* self)		{ return self->targetWidth.has_value()		? self->targetWidth.value()	: -1; } 
-int64_t LayerSource_targetHeight_get(LayerSource* self)		{ return self->targetHeight.has_value()		? self->targetHeight.value()	: -1; } 
-int64_t LayerSource_targetFps_get(LayerSource* self)		{ return self->targetFps.has_value()		? self->targetFps.value()	: -1; } 
+int64_t LayerSource_targetBitrate_get(LayerSource* self)	{ return self->targetBitrate.value_or(0);	} 
+int64_t LayerSource_targetWidth_get(LayerSource* self)		{ return self->targetWidth.value_or(0);		} 
+int64_t LayerSource_targetHeight_get(LayerSource* self)		{ return self->targetHeight.value_or(0);	} 
+int64_t LayerSource_targetFps_get(LayerSource* self)		{ return self->targetFps.value_or(0);		} 
 %}
 
 class LayerSources

--- a/src/media-server.d.ts
+++ b/src/media-server.d.ts
@@ -343,6 +343,14 @@ export  class RTPIncomingSource extends RTPSource {
 
   height: number;
 
+  targetBitrate: number;
+
+  targetWidth: number;
+
+  targetHeight: number;
+
+  targetFps: number;
+
   layers(): LayerSources;
 
   constructor();

--- a/src/media-server_wrap.cxx
+++ b/src/media-server_wrap.cxx
@@ -1564,9 +1564,6 @@ public:
 		
 		//Init async handler
 		uv_async_init(uv_default_loop(), &async, async_cb_handler);
-
-		//Init random numbers
-		srand(time(NULL));
 	}
 	
 	static void Terminate()
@@ -2459,6 +2456,12 @@ SWIGINTERN LayerSources RTPIncomingSource_layers__SWIG(RTPIncomingSource *self){
 				layers.push_back(&(it->second));
 			return layers;
 		}
+
+int64_t RTPIncomingSource_targetBitrate_get(RTPIncomingSource* self)	{ return self->targetBitrate.has_value()	? self->targetBitrate.value()	: -1; } 
+int64_t RTPIncomingSource_targetWidth_get(RTPIncomingSource* self)	{ return self->targetWidth.has_value()		? self->targetWidth.value()	: -1; } 
+int64_t RTPIncomingSource_targetHeight_get(RTPIncomingSource* self)	{ return self->targetHeight.has_value()		? self->targetHeight.value()	: -1; } 
+int64_t RTPIncomingSource_targetFps_get(RTPIncomingSource* self)	{ return self->targetFps.has_value()		? self->targetFps.value()	: -1; } 
+
 SWIGINTERN void RTPIncomingSourceGroup_UpdateAsync__SWIG(RTPIncomingSourceGroup *self,v8::Local< v8::Object > object){
 		auto persistent = std::make_shared<Persistent<v8::Object>>(object);
 		self->UpdateAsync([=](std::chrono::milliseconds){
@@ -9125,6 +9128,110 @@ static SwigV8ReturnValue _wrap_RTPIncomingSource_layers(const SwigV8Arguments &a
   goto fail;
 fail:
   SWIGV8_RETURN(SWIGV8_UNDEFINED());
+}
+
+
+static SwigV8ReturnValue _wrap_RTPIncomingSource_targetBitrate_get(v8::Local<v8::Name> property, const SwigV8PropertyCallbackInfo &info) {
+  SWIGV8_HANDLESCOPE();
+  
+  SWIGV8_VALUE jsresult;
+  RTPIncomingSource *arg1 = (RTPIncomingSource *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int64_t result;
+  
+  res1 = SWIG_ConvertPtr(info.Holder(), &argp1,SWIGTYPE_p_RTPIncomingSource, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "RTPIncomingSource_targetBitrate_get" "', argument " "1"" of type '" "RTPIncomingSource *""'"); 
+  }
+  arg1 = reinterpret_cast< RTPIncomingSource * >(argp1);
+  result = (int64_t)RTPIncomingSource_targetBitrate_get(arg1);
+  jsresult = SWIG_From_long_SS_long(static_cast< long long >(result));
+  
+  
+  SWIGV8_RETURN_INFO(jsresult, info);
+  
+  goto fail;
+fail:
+  SWIGV8_RETURN_INFO(SWIGV8_UNDEFINED(), info);
+}
+
+
+static SwigV8ReturnValue _wrap_RTPIncomingSource_targetWidth_get(v8::Local<v8::Name> property, const SwigV8PropertyCallbackInfo &info) {
+  SWIGV8_HANDLESCOPE();
+  
+  SWIGV8_VALUE jsresult;
+  RTPIncomingSource *arg1 = (RTPIncomingSource *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int64_t result;
+  
+  res1 = SWIG_ConvertPtr(info.Holder(), &argp1,SWIGTYPE_p_RTPIncomingSource, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "RTPIncomingSource_targetWidth_get" "', argument " "1"" of type '" "RTPIncomingSource *""'"); 
+  }
+  arg1 = reinterpret_cast< RTPIncomingSource * >(argp1);
+  result = (int64_t)RTPIncomingSource_targetWidth_get(arg1);
+  jsresult = SWIG_From_long_SS_long(static_cast< long long >(result));
+  
+  
+  SWIGV8_RETURN_INFO(jsresult, info);
+  
+  goto fail;
+fail:
+  SWIGV8_RETURN_INFO(SWIGV8_UNDEFINED(), info);
+}
+
+
+static SwigV8ReturnValue _wrap_RTPIncomingSource_targetHeight_get(v8::Local<v8::Name> property, const SwigV8PropertyCallbackInfo &info) {
+  SWIGV8_HANDLESCOPE();
+  
+  SWIGV8_VALUE jsresult;
+  RTPIncomingSource *arg1 = (RTPIncomingSource *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int64_t result;
+  
+  res1 = SWIG_ConvertPtr(info.Holder(), &argp1,SWIGTYPE_p_RTPIncomingSource, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "RTPIncomingSource_targetHeight_get" "', argument " "1"" of type '" "RTPIncomingSource *""'"); 
+  }
+  arg1 = reinterpret_cast< RTPIncomingSource * >(argp1);
+  result = (int64_t)RTPIncomingSource_targetHeight_get(arg1);
+  jsresult = SWIG_From_long_SS_long(static_cast< long long >(result));
+  
+  
+  SWIGV8_RETURN_INFO(jsresult, info);
+  
+  goto fail;
+fail:
+  SWIGV8_RETURN_INFO(SWIGV8_UNDEFINED(), info);
+}
+
+
+static SwigV8ReturnValue _wrap_RTPIncomingSource_targetFps_get(v8::Local<v8::Name> property, const SwigV8PropertyCallbackInfo &info) {
+  SWIGV8_HANDLESCOPE();
+  
+  SWIGV8_VALUE jsresult;
+  RTPIncomingSource *arg1 = (RTPIncomingSource *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int64_t result;
+  
+  res1 = SWIG_ConvertPtr(info.Holder(), &argp1,SWIGTYPE_p_RTPIncomingSource, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "RTPIncomingSource_targetFps_get" "', argument " "1"" of type '" "RTPIncomingSource *""'"); 
+  }
+  arg1 = reinterpret_cast< RTPIncomingSource * >(argp1);
+  result = (int64_t)RTPIncomingSource_targetFps_get(arg1);
+  jsresult = SWIG_From_long_SS_long(static_cast< long long >(result));
+  
+  
+  SWIGV8_RETURN_INFO(jsresult, info);
+  
+  goto fail;
+fail:
+  SWIGV8_RETURN_INFO(SWIGV8_UNDEFINED(), info);
 }
 
 
@@ -17748,6 +17855,10 @@ SWIGV8_AddMemberVariable(_exports_RTPIncomingSource_class, "aggregatedLayers", _
 SWIGV8_AddMemberVariable(_exports_RTPIncomingSource_class, "width", _wrap_RTPIncomingSource_width_get, _wrap_RTPIncomingSource_width_set);
 SWIGV8_AddMemberVariable(_exports_RTPIncomingSource_class, "height", _wrap_RTPIncomingSource_height_get, _wrap_RTPIncomingSource_height_set);
 SWIGV8_AddMemberFunction(_exports_RTPIncomingSource_class, "layers", _wrap_RTPIncomingSource_layers);
+SWIGV8_AddMemberVariable(_exports_RTPIncomingSource_class, "targetBitrate", _wrap_RTPIncomingSource_targetBitrate_get, JS_veto_set_variable);
+SWIGV8_AddMemberVariable(_exports_RTPIncomingSource_class, "targetWidth", _wrap_RTPIncomingSource_targetWidth_get, JS_veto_set_variable);
+SWIGV8_AddMemberVariable(_exports_RTPIncomingSource_class, "targetHeight", _wrap_RTPIncomingSource_targetHeight_get, JS_veto_set_variable);
+SWIGV8_AddMemberVariable(_exports_RTPIncomingSource_class, "targetFps", _wrap_RTPIncomingSource_targetFps_get, JS_veto_set_variable);
 SWIGV8_AddMemberVariable(_exports_RTPIncomingSourceGroup_class, "rid", _wrap_RTPIncomingSourceGroup_rid_get, _wrap_RTPIncomingSourceGroup_rid_set);
 SWIGV8_AddMemberVariable(_exports_RTPIncomingSourceGroup_class, "mid", _wrap_RTPIncomingSourceGroup_mid_get, _wrap_RTPIncomingSourceGroup_mid_set);
 SWIGV8_AddMemberVariable(_exports_RTPIncomingSourceGroup_class, "rtt", _wrap_RTPIncomingSourceGroup_rtt_get, _wrap_RTPIncomingSourceGroup_rtt_set);

--- a/src/media-server_wrap.cxx
+++ b/src/media-server_wrap.cxx
@@ -2190,10 +2190,10 @@ SWIGV8_VALUE SWIG_From_unsigned_SS_long_SS_long  (unsigned long long value)
 #endif
 
 
-int64_t LayerSource_targetBitrate_get(LayerSource* self)	{ return self->targetBitrate.has_value()	? self->targetBitrate.value()	: -1; } 
-int64_t LayerSource_targetWidth_get(LayerSource* self)		{ return self->targetWidth.has_value()		? self->targetWidth.value()	: -1; } 
-int64_t LayerSource_targetHeight_get(LayerSource* self)		{ return self->targetHeight.has_value()		? self->targetHeight.value()	: -1; } 
-int64_t LayerSource_targetFps_get(LayerSource* self)		{ return self->targetFps.has_value()		? self->targetFps.value()	: -1; } 
+int64_t LayerSource_targetBitrate_get(LayerSource* self)	{ return self->targetBitrate.value_or(0);	} 
+int64_t LayerSource_targetWidth_get(LayerSource* self)		{ return self->targetWidth.value_or(0);		} 
+int64_t LayerSource_targetHeight_get(LayerSource* self)		{ return self->targetHeight.value_or(0);	} 
+int64_t LayerSource_targetFps_get(LayerSource* self)		{ return self->targetFps.value_or(0);		} 
 
 
 SWIGINTERNINLINE SWIGV8_VALUE
@@ -2457,10 +2457,10 @@ SWIGINTERN LayerSources RTPIncomingSource_layers__SWIG(RTPIncomingSource *self){
 			return layers;
 		}
 
-int64_t RTPIncomingSource_targetBitrate_get(RTPIncomingSource* self)	{ return self->targetBitrate.has_value()	? self->targetBitrate.value()	: -1; } 
-int64_t RTPIncomingSource_targetWidth_get(RTPIncomingSource* self)	{ return self->targetWidth.has_value()		? self->targetWidth.value()	: -1; } 
-int64_t RTPIncomingSource_targetHeight_get(RTPIncomingSource* self)	{ return self->targetHeight.has_value()		? self->targetHeight.value()	: -1; } 
-int64_t RTPIncomingSource_targetFps_get(RTPIncomingSource* self)	{ return self->targetFps.has_value()		? self->targetFps.value()	: -1; } 
+int64_t RTPIncomingSource_targetBitrate_get(RTPIncomingSource* self)	{ return self->targetBitrate.value_or(0); } 
+int64_t RTPIncomingSource_targetWidth_get(RTPIncomingSource* self)	{ return self->targetWidth.value_or(0); }  
+int64_t RTPIncomingSource_targetHeight_get(RTPIncomingSource* self)	{ return self->targetHeight.value_or(0); } 
+int64_t RTPIncomingSource_targetFps_get(RTPIncomingSource* self)	{ return self->targetFps.value_or(0); }  
 
 SWIGINTERN void RTPIncomingSourceGroup_UpdateAsync__SWIG(RTPIncomingSourceGroup *self,v8::Local< v8::Object > object){
 		auto persistent = std::make_shared<Persistent<v8::Object>>(object);


### PR DESCRIPTION
If VLA is used with a single layer stream with no layer info (for example an h264 stream), a new `LayerSource` was created for storing the target bitrate/width/heigh/fps, but it was not used for calculating the other stats

So when the stats where gathered, as there was already a single layer, the code to create a default layer for the source if no layer info was present, was not run, and therefore the bitrate field was not exposed correctly.

With the change on the media server, we are adding the target stats to the `RTPIncomingSource` as well and not creating a `LayerSource`.

This PR exposes the target stats at source level and so the `getActiveLayers()` provide the correct info. 

