### PR TITLE
prevent "not dumping" C++ errors

### DIFF
--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -247,7 +247,8 @@ class Transport extends Emitter
 		const bwe		= options ? Boolean(options.bwe) : true;
 		
 		//Check we are dumping anything
-		if (incoming || outgoing || rtcp) {
+		if (incoming || outgoing || rtcp)
+		{
 			//Start dumping
 			if (!this.transport.Dump(filename, incoming, outgoing, rtcp, rtpHeadersOnly))
 				throw new Error("Could not dump to pcap file");

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -247,15 +247,17 @@ class Transport extends Emitter
 		const bwe		= options ? Boolean(options.bwe) : true;
 		
 		//Check we are dumping anything
-		if (incoming || outgoing || rtcp)
+		if (incoming || outgoing || rtcp) {
 			//Start dumping
 			if (!this.transport.Dump(filename, incoming, outgoing, rtcp, rtpHeadersOnly))
-				throw new Error("Could no dump to pcap file");
+				throw new Error("Could not dump to pcap file");
+			this.dumping = true;
+		}
 		//Check if we are dumping bwe
 		if (bwe && typeof filename==="string")
 			//Start dumping
 			if (!this.transport.DumpBWEStats(filename.replace(".pcap",".csv")))
-				throw new Error("Could no dump to bwe csv file");
+				throw new Error("Could not dump to bwe csv file");
 	}
 	
 	/**
@@ -264,7 +266,9 @@ class Transport extends Emitter
 	stopDump()
 	{
 		//Stop
-		this.transport.StopDump();
+		if (this.dumping)
+			this.transport.StopDump();
+		this.dumping = false;
 		this.transport.StopDumpBWEStats();
 	}
 	


### PR DESCRIPTION
calling `transport.dump()` and then `transport.stopDump()` currently causes C++ to print a "not dumping" error if only BWE was requested in the call to dump():

~~~
[61519 VIEW4     ][1701274443.460][ERR]-DTLSICETransport::StopDump() | Not dumping
~~~

this is currently spamming our logs a bit. so, have Transport track state and avoid unnecessary C++ calls.

an alternative is to remove the C++ Error() log line.