### PR TITLE
fix Transponder encoding re-selection

### DIFF
--- a/lib/Transponder.js
+++ b/lib/Transponder.js
@@ -55,6 +55,7 @@ class Transponder extends Emitter
 		//No track
 		this.track = /** @type {IncomingStreamTrack | null} */ (null);
 		this.encodingId = /** @type {string | null} */ (null);
+		this.encoding = /** @type {IncomingStreamTrack.Encoding | null} */ (null);
 		this.muted = false;
 		this.spatialLayerId = LayerInfo.MaxLayerId;
 		this.temporalLayerId = LayerInfo.MaxLayerId;
@@ -75,6 +76,7 @@ class Transponder extends Emitter
 			this.transponder.ResetIncoming();
 			//No encoding
 			this.encodingId = null;
+			this.encoding = null;
 		};
 		//Listener for when new encodings become avialable
 		this.onAttachedTrackEncoding = (
@@ -175,6 +177,7 @@ class Transponder extends Emitter
 			this.transponder.ResetIncoming();
 			//No encoding
 			this.encodingId = null;
+			this.encoding = null;
 		}
 	}
 	
@@ -636,20 +639,21 @@ class Transponder extends Emitter
 	 */
 	selectEncoding(encodingId,smooth) 
 	{
-		//If not changed
-		if (this.encodingId==encodingId)
-			//Do nothing
-			return;
 		//Get encoding 
 		const encoding = this.track.getEncoding(encodingId);
 		//If not found
 		if (!encoding)
 			//Error
 			throw new Error("Encoding id ["+encodingId+"] not found on transpoder track");
+		//If not changed
+		if (encoding===this.encoding)
+			//Do nothing
+			return;
 		//Start listening to it
 		this.transponder.SetIncoming(encoding.source.toRTPIncomingMediaStream(),encoding.receiver,!!smooth);
 		//store encoding
 		this.encodingId = encodingId;
+		this.encoding = encoding;
 	}
 	
 	/**


### PR DESCRIPTION
the Transponder listens for `encoding` events on the assigned track. if an encoding with the same ID as the current one is emitted, it will re-select it by calling `selectEncoding()` again:

https://github.com/medooze/media-server-node/blob/91226d64cde3109d59be80233920acbc8c6d0242/lib/Transponder.js#L84-L89

this doesn't work in practice because the first thing `selectEncoding()` does is reject calls for the same encoding ID as the currently stored one:

https://github.com/medooze/media-server-node/blob/91226d64cde3109d59be80233920acbc8c6d0242/lib/Transponder.js#L637-L642

I understand we're doing this to avoid unnecessary calls to C++, so instead of checking for a change in encoding ID, we should check for a change in the encoding object itself or in the RTP sources directly. I've opted for the former.