### PR TITLE
Add CreateTransportOptions to PeerConnectionServer constructor

### DIFF
--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -249,10 +249,10 @@ class Endpoint extends Emitter
 	 */
 	createTransport(remoteInfo, localInfo, options)
 	{
-		//Check we have a transport alredy
+		//Check we have a transport already
 		if (!this.bundle)
 			//Error
-			throw new Error("Endpoint is alredy stopped, cannot create transport");
+			throw new Error("Endpoint is already stopped, cannot create transport");
 		
 		const remote = parsePeerInfo(remoteInfo);
 		
@@ -326,13 +326,14 @@ class Endpoint extends Emitter
 	/**
 	 * Create new peer connection server to manage remote peer connection clients
 	 * @param {any} tm
-	 * @param {SemanticSDP.Capabilities} capabilities - Same as SDPInfo.answer capabilites
+	 * @param {SemanticSDP.Capabilities} capabilities - Same as SDPInfo.answer capabilities
+	 * @param {CreateTransportOptions} options
 	 * @returns {PeerConnectionServer}
 	 */
-	createPeerConnectionServer(tm,capabilities)
+	createPeerConnectionServer(tm,capabilities,options)
 	{
 		//Create new one 
-		return new PeerConnectionServer(this,tm,capabilities);
+		return new PeerConnectionServer(this,tm,capabilities,options);
 	}
 	
 	/**

--- a/lib/PeerConnectionServer.js
+++ b/lib/PeerConnectionServer.js
@@ -48,7 +48,6 @@ class PeerConnectionServer extends Emitter
 		this.endpoint = endpoint;
 		this.capabilities = capabilities;
 		this.tm = tm;
-		this.options = options;
 		
 		//The created transports
 		this.transports = /** @type {Set<Transport>} */ (new Set());

--- a/lib/PeerConnectionServer.js
+++ b/lib/PeerConnectionServer.js
@@ -37,7 +37,8 @@ class PeerConnectionServer extends Emitter
 	constructor(
 		/** @type {import("./Endpoint")} */ endpoint,
 		/** @type {any} */ tm,
-		/** @type {SemanticSDP.Capabilities} */ capabilities)
+		/** @type {SemanticSDP.Capabilities} */ capabilities,
+		/** @type {import("./Endpoint").CreateTransportOptions} */ options)
 	{
 		//Init emitter
 		super();
@@ -47,6 +48,7 @@ class PeerConnectionServer extends Emitter
 		this.endpoint = endpoint;
 		this.capabilities = capabilities;
 		this.tm = tm;
+		this.options = options;
 		
 		//The created transports
 		this.transports = /** @type {Set<Transport>} */ (new Set());
@@ -63,7 +65,7 @@ class PeerConnectionServer extends Emitter
 					//Process the sdp
 					var offer = SDPInfo.expand(cmd.data);
 					//Create an DTLS ICE transport in that enpoint
-					const transport = this.endpoint.createTransport(offer);
+					const transport = this.endpoint.createTransport(offer, null, options);
 					
 					//Set RTP remote properties
 					transport.setRemoteProperties(offer);


### PR DESCRIPTION
This opens up the override options needed to to disabling e.g. REMB (disableREMB) as a CreateTransportOptions is misssing when creating the PeerConnectionServer

Handles issue from #240 