### PR TITLE
fix reported REMB stat

### DIFF
--- a/lib/IncomingStreamTrack.js
+++ b/lib/IncomingStreamTrack.js
@@ -166,7 +166,7 @@ function getEncodingStats(/** @type {Encoding} */ encoding)
 		numFramesDelta	: mediaStats.numFramesDelta,
 		numPackets	: mediaStats.numPackets + rtxStats.numPackets,
 		numPacketsDelta	: mediaStats.numPacketsDelta + rtxStats.numPacketsDelta,
-		remb		: encoding.remoteBitrateEstimation,
+		remb		: encoding.source.remoteBitrateEstimation,
 		// timestamps
 		timestamp: Date.now(),
 		// provisional (set by updateStatsSimulcastIndex)

--- a/src/RTPIncomingSourceGroup.i
+++ b/src/RTPIncomingSourceGroup.i
@@ -14,6 +14,7 @@ struct RTPIncomingSourceGroup : public RTPIncomingMediaStream
 	MediaFrameType  type;
 	const RTPIncomingSource media;
 	const RTPIncomingSource rtx;
+	DWORD remoteBitrateEstimation;
 	DWORD lost;
 	DWORD minWaitedTime;
 	DWORD maxWaitedTime;

--- a/src/media-server.d.ts
+++ b/src/media-server.d.ts
@@ -378,6 +378,8 @@ export  class RTPIncomingSourceGroup extends RTPIncomingMediaStream {
 
   rtx: RTPIncomingSource;
 
+  remoteBitrateEstimation: number;
+
   lost: number;
 
   minWaitedTime: number;


### PR DESCRIPTION
to my knowledge the 'remb' property on incoming encoding stats has never worked since it was added at d469b6f, but I guess better late than never 😅

(I don't think we're using this ourselves, we never do REMB when receiving AFAIK)