### PR TITLE
jsdoc annotation fixes

### DIFF
--- a/lib/IncomingStream.js
+++ b/lib/IncomingStream.js
@@ -227,7 +227,7 @@ class IncomingStream extends Emitter
 	
 	
 	/**
-	 * Adds an incoming stream track created using {@link Transponder.createIncomingStreamTrack} to this stream
+	 * Adds an incoming stream track created using {@link Transport.createIncomingStreamTrack} to this stream
 	 *  
 	 * @param {IncomingStreamTrack} incomingStreamTrack
 	 */

--- a/lib/IncomingStreamTrack.js
+++ b/lib/IncomingStreamTrack.js
@@ -84,10 +84,10 @@ const {
  * 
  * @property {number} [rtt] Round Trip Time in ms
  * @property {number} bitrate Bitrate for media stream only in bps
- * @deprecated @property {number} total Accumulated bitrate for media and rtx streams in bps (Deprecated)
+ * @property {number} total Accumulated bitrate for media and rtx streams in bps (Deprecated)
  * @property {number} totalBitrate average total bitrate received during last second for this layer
  * @property {number} totalBytes total rtp received bytes for this layer
- * @property {number} [remb] Estimated available bitrate for receving (only available if not using transport wide cc)
+ * @property {number} [remb] Estimated available bitrate for receiving (only available if not using transport wide cc)
  * @property {number} simulcastIdx Simulcast layer index based on bitrate received (-1 if it is inactive).
  * @property {number} [lostPacketsRatio] Lost packets ratio
  * @property {number} [width] video width

--- a/lib/IncomingStreamTrackSimulcastAdapter.js
+++ b/lib/IncomingStreamTrackSimulcastAdapter.js
@@ -119,15 +119,6 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 			//Attach the simulcast depacketizer to the source media producer
 			this.depacketizer.AttachTo(mirrored.depacketizer.toMediaFrameProducer());
 
-			/**
-			* IncomingStreamTrack new encoding event
-			*
-			* @name encoding
-			* @memberof IncomingStreamTrack
-			* @kind event
-			* @argument {IncomingStreamTrack} incomingStreamTrack
-		        * @argument {Object} encoding
-			*/
 			this.emit("encoding",this,mirrored);
 		}
 

--- a/lib/OutgoingStreamTrack.js
+++ b/lib/OutgoingStreamTrack.js
@@ -29,7 +29,7 @@ const Transponder	= require("./Transponder");
  * @property {number} numPacketsDelta number of rtp packets sent during last second 
  * @property {number} rtt Round Trip Time in ms
  * @property {number} bitrate Bitrate for media stream only in bps
- * @deprecated @property {number} total Accumulated bitrate for media, rtx and fec streams in bps
+ * @property {number} total Accumulated bitrate for media, rtx and fec streams in bps (deprecated)
  * @property {number} totalBitrate Accumulated bitrate for media, rtx and fec streams in bps
  * @property {number} totalBytes total rtp sent bytes for this layer
  */

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -40,7 +40,7 @@ const noop = function(){};
 
 /**
  * @typedef {Object} TransportDumpOptions
- * @property {boolean} [incoming] Dump incomoning RTP data [Default: true]
+ * @property {boolean} [incoming] Dump incoming RTP data [Default: true]
  * @property {boolean} [outgoing] Dump outgoing RTP data [Default: true]
  * @property {boolean} [rtcp] Dump rtcp RTP data [Default: true]
  * @property {boolean} [rtpHeadersOnly] Dump only rtp headers and first 16 bytes of payload for rtp packets [Default: false]
@@ -375,8 +375,8 @@ class Transport extends Emitter
 	
 	/**
 	 * Enable bitrate probing.
-	 * This will send padding only RTX packets to allow bandwidth estimation algortithm to probe bitrate beyonf current sent values.
-	 * The ammoung of probing bitrate would be limited by the sender bitrate estimation and the limit set on the setMaxProbing Bitrate.
+	 * This will send padding only RTX packets to allow bandwidth estimation algortithm to probe bitrate beyond current sent values.
+	 * The amount of probing bitrate would be limited by the sender bitrate estimation and the limit set on the setMaxProbing Bitrate.
 	 * Note that this will only work on browsers that supports RTX and transport wide cc.
 	 * @param {boolean} probe
 	 */
@@ -414,7 +414,7 @@ class Transport extends Emitter
 
 
 	/**
-	 * Override the bitrate sent by REMB to the remote sender. The transport must be constructed with teh override bwe option, and transport wide cc must not be offered.
+	 * Override the bitrate sent by REMB to the remote sender. The transport must be constructed with the override bwe option, and transport wide cc must not be offered.
 	 * @param {Number} bitrate
 	 */
 	setRemoteOverrideBitrate(bitrate)


### PR DESCRIPTION
bunch of small fixes in the JSDoc comments I had pending to push for some weeks.

- first, do not use `@deprecated` for `@property` annotations since TypeScript doesn't yet support them, and they break the whole comment parsing.

- then, fix some typos.