### PR TITLE
Use npm pack and Github Actions to publish releases to npmjs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
       - 'lester/*'
 
 jobs:
-  publish-to-github-packages:
+  publish-npmjs:
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,18 @@
+name: Publish
+on: 
+  release:
+   types: [published]
+  push:
+    branches:
+      - 'lester/*'
+
+jobs:
+  publish-to-github-packages:
+    permissions:
+      packages: write
+      contents: read
+    uses: millicast/github-actions/.github/workflows/npm-publish.yml@main
+    with:
+      registry-url: 'https://registry.npmjs.org/'
+    secrets:
+      token: ${{ secrets.NPMJS_PUBLISH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,8 @@
 name: Publish
 on: 
-  release:
-   types: [published]
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   publish-npmjs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,6 @@ name: Publish
 on: 
   release:
    types: [published]
-  push:
-    branches:
-      - 'lester/*'
 
 jobs:
   publish-npmjs:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "build": "node-gyp build --jobs=max",
     "install": "test -f build/Release/medooze-media-server.node || (node-gyp configure && node-gyp rebuild --jobs=max)",
     "docs": "documentation build lib/MediaServer.js lib/*.js --shallow -o docs -f html && documentation build lib/MediaServer.js lib/*.js --shallow -o api.md -f md --markdown-toc false",
-    "package": "npm run prepare && tar cvzf build/medooze-media-server.tgz  `([ \"$(uname)\" = 'Darwin' ] && echo \"-s |^|medooze-media-server/|\") || echo \" --transform=flags=r;s|^|medooze-media-server/|\"` external/* media-server/src/* media-server/include/* media-server/ext/libdatachannels/src/* media-server/ext/crc32c/* lib/* package.json index.js index.d.ts build/types binding.gyp README.md src",
     "dist": "npm run configure && npm run build && npm run prepare && mkdir -p dist && tar cvzf dist/medooze-media-server-`node -e 'console.log(require(\"./package.json\").version)'`.tgz `([ \"$(uname)\" = 'Darwin' ] && echo \"-s |^|medooze-media-server/|\") || echo \" --transform=flags=r;s|^|medooze-media-server/|\"` package.json index.js index.d.ts build/types README.md lib/* build/Release/medooze-media-server.node",
     "test": "tap tests/*.js --cov --no-check-coverage --reporter dump --jobs 1"
   },
@@ -48,5 +47,20 @@
     "documentation": "13.2.5",
     "tap": "^16.3.9",
     "typescript": "^5.2.2"
-  }
+  },
+  "files": [
+    "external/*",
+    "media-server/src/*",
+    "media-server/include/*",
+    "media-server/ext/libdatachannels/src/*",
+    "media-server/ext/crc32c/*",
+    "lib/*",
+    "package.json",
+    "index.js",
+    "index.d.ts",
+    "build/types",
+    "binding.gyp",
+    "README.md",
+    "src"
+  ]
 }


### PR DESCRIPTION
Diff between packages is npm adds licenses and readme's, and removes .git config:

![image](https://github.com/medooze/media-server-node/assets/145613755/1014eeb5-9b08-4a8a-9071-9d0a72daac8b)

Sample publishing job:
https://github.com/medooze/media-server-node/actions/runs/9036679574/job/24834054462