### PR TITLE
SimulcastAdapter: wait for track to be fully removed before emitting encodingremoved

### DIFF
--- a/lib/IncomingStreamTrackSimulcastAdapter.js
+++ b/lib/IncomingStreamTrackSimulcastAdapter.js
@@ -161,8 +161,6 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 			this.encodings.delete(encoding.id);
 			//Detach the simulcast depacketizer to the source media producer
 			this.depacketizer.Detach(encoding.depacketizer.toMediaFrameProducer());
-			//Fire event
-			this.emit("encodingremoved", this, encoding);
 		}
 		//Update the number of layers
 		this.depacketizer.SetNumLayers(this.encodings.size);
@@ -178,6 +176,10 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 			for (let i= 0; i<this.counter; ++i)
 				//Signal original track is dettached
 				incomingStreamTrack.detached();
+
+		// Emit all pending encodingremoved events
+		for (const [id,encoding] of encodings)
+			this.emit("encodingremoved", this, encoding);
 	}
 
 	/**


### PR DESCRIPTION
fixes a little flaw of #257.

when SimulcastAdapter emits encodingremoved for a certain encoding, it is still present in `this.encodingsPerTrack`, meaning it is still reflected in `getActiveLayers()`. to be safe, defer event emitting until the track removal is done.