### PR TITLE
feat: add support for unsignaled sources

### DIFF
--- a/lib/IncomingStreamTrack.js
+++ b/lib/IncomingStreamTrack.js
@@ -555,58 +555,73 @@ class IncomingStreamTrack extends Emitter
 
 		//If multiple sources and got time service
 		if (num > 1 && timeService)
-			//Create a simulcast frame listerner
-			this.depacketizer = SharedPointer(new Native.SimulcastMediaFrameListenerShared(timeService, 1, num));
+		{
+			//Create a simulcast frame listerner for selecting best frame from all sources
+			/** @type {SharedPointer.Proxy<Native.SimulcastMediaFrameListenerShared>} */
+			this.simulcastDepacketizer =  SharedPointer(new Native.SimulcastMediaFrameListenerShared(timeService, 1, num));
+			//Use it as default
+			/** @type {SharedPointer.Proxy<Native.SimulcastMediaFrameListenerShared | Native.RTPIncomingMediaStreamDepacketizerShared>} */
+			this.depacketizer = this.simulcastDepacketizer;
+		}
 		
 		//For each source
 		for (let [id, source] of Object.entries(sources))
-		{
-			//The encoding
-			const encoding = {
-				id		: id,
-				source		: source,
-				receiver	: receiver,
-				depacketizer	: SharedPointer(new Native.RTPIncomingMediaStreamDepacketizerShared(source.toRTPIncomingMediaStream()))
-			};
-			
-			//Push new encoding
-			this.encodings.set(id, encoding);
-			
-			//If multiple encodings
-			if (this.depacketizer)
-				//Add the source depacketizer producer
-				(/** @type {SharedPointer.Proxy<Native.SimulcastMediaFrameListenerShared>} */ (this.depacketizer))
-					.AttachTo(encoding.depacketizer.toMediaFrameProducer());
-			
-			//Add ssrcs to track info
-			source.media && source.media.ssrc && this.trackInfo.addSSRC(source.media.ssrc);
-			source.rtx && source.rtx.ssrc && this.trackInfo.addSSRC(source.rtx.ssrc);
-			
-			//Add RTX groups
-			source.rtx && source.rtx.ssrc && this.trackInfo.addSourceGroup(new SourceGroupInfo("FID",[source.media.ssrc,source.rtx.ssrc]));
-			
-			//If doing simulcast
-			if (id)
-			{
-				//Create simulcast info
-				const encodingInfo = new TrackEncodingInfo(id, false);
-				//If we have ssrc info also
-				if (source.media && source.media.ssrc)
-					//Add main ssrc
-					encodingInfo.addParam("ssrc",String(source.media.ssrc));
-				//Add it
-				this.trackInfo.addEncoding(encodingInfo);
-			}
+			//Add source
+			this.addIncomingSource(id, source);
 
-			//Init stats
-			this.stats[encoding.id] = getEncodingStats(encoding);
-		}
-
-		//If there is no depacketizer
+		//If there is no simulcast depacketizer used
 		if (!this.depacketizer)
 			//This is the single depaquetizer, so reause it
 			/** @type {SharedPointer.Proxy<Native.SimulcastMediaFrameListenerShared | Native.RTPIncomingMediaStreamDepacketizerShared>} */
 			this.depacketizer = this.getDefaultEncoding().depacketizer;
+	}
+
+	addIncomingSource(
+		/** @type string*/ id,
+		/** @type SharedPointer.Proxy<Native.RTPIncomingSourceGroupShared> */ source,
+	)
+	{
+		//The encoding
+		const encoding = {
+			id		: id,
+			source		: source,
+			receiver	: this.receiver,
+			depacketizer	: SharedPointer(new Native.RTPIncomingMediaStreamDepacketizerShared(source.toRTPIncomingMediaStream()))
+		};
+			
+		//Push new encoding
+		this.encodings.set(id, encoding);
+			
+		//If multiple encodings
+		if (this.simulcastDepacketizer)
+			//Add the source depacketizer producer
+			this.simulcastDepacketizer.AttachTo(encoding.depacketizer.toMediaFrameProducer());
+			
+		//Add ssrcs to track info
+		source.media && source.media.ssrc && this.trackInfo.addSSRC(source.media.ssrc);
+		source.rtx && source.rtx.ssrc && this.trackInfo.addSSRC(source.rtx.ssrc);
+			
+		//Add RTX groups
+		source.rtx && source.rtx.ssrc && this.trackInfo.addSourceGroup(new SourceGroupInfo("FID",[source.media.ssrc,source.rtx.ssrc]));
+			
+		//If doing simulcast
+		if (id)
+		{
+			//Create simulcast info
+			const encodingInfo = new TrackEncodingInfo(id, false);
+			//If we have ssrc info also
+			if (source.media && source.media.ssrc)
+				//Add main ssrc
+				encodingInfo.addParam("ssrc",String(source.media.ssrc));
+			//Add it
+			this.trackInfo.addEncoding(encodingInfo);
+		}
+
+		//Init stats
+		this.stats[encoding.id] = getEncodingStats(encoding);
+
+		//Emit encoding event, nobody will be listening when called from constructor
+		this.emit("encoding", this, encoding);
 	}
 	
 	/**
@@ -935,11 +950,10 @@ class IncomingStreamTrack extends Emitter
 		//for each encoding
 		for (let encoding of this.encodings.values())
 		{	
-			//If multiple encodings
-			if (this.depacketizer != encoding.depacketizer)
+			//If we are using a simulcast depacketizer for multiple encodings
+			if (this.simulcastDepacketizer)
 				//Remove frame listener
-				(/** @type {SharedPointer.Proxy<Native.SimulcastMediaFrameListenerShared>} */ (this.depacketizer))
-					.Detach(encoding.depacketizer.toMediaFrameProducer());
+				this.simulcastDepacketizer.Detach(encoding.depacketizer.toMediaFrameProducer());
 			//Stop the depacketizer
 			encoding.depacketizer.Stop();
 			//Stop source

--- a/lib/IncomingStreamTrackMirrored.js
+++ b/lib/IncomingStreamTrackMirrored.js
@@ -87,7 +87,7 @@ class IncomingStreamTrackMirrored extends Emitter
 			//Push new encoding
 			this.encodings.set(mirrored.id, mirrored);
 
-			this.emit("encoding",this,mirrored);
+			return mirrored;
 		}
 
 		//For each encoding in the original track
@@ -96,9 +96,11 @@ class IncomingStreamTrackMirrored extends Emitter
 			addEncoding(encoding);
 		
 		//LIsten for new encodings
-		incomingStreamTrack.on("encoding",(incomingStreamTrack,encoding) => {
+		incomingStreamTrack.prependListener("encoding",(incomingStreamTrack,encoding) => {
 			//Add new encoding
-			addEncoding(encoding);
+			const mirrored = addEncoding(encoding);
+			//Emit new event up
+			this.emit("encoding", this, mirrored);
 		});
 		incomingStreamTrack.on("encodingremoved",(incomingStreamTrack,encoding) => {
 			//Get mirrored encoder
@@ -227,7 +229,7 @@ class IncomingStreamTrackMirrored extends Emitter
 	 **/
 	getDefaultEncoding()
 	{
-		return [...this.encodings.values()][0];
+		return this.encodings.get('') || [...this.encodings.values()][0];
 	}
 
 	/**

--- a/lib/OutgoingStream.js
+++ b/lib/OutgoingStream.js
@@ -343,6 +343,17 @@ class OutgoingStream extends Emitter
 			//Set fec ssrc
 			source.fec.ssrc = FEC_FR ? FEC_FR.getSSRCs()[1] : 0;
 
+			//Get encodings
+			const encodings	 = trackInfo.getEncodings();
+
+			//Get rid
+			const rid = encodings?.length == 1 && encodings[0].length == 1
+				? encodings[0][0].getId() : undefined;
+
+			if (rid)
+				source.rid = rid;
+
+
 		} else {
 			params = /** @type {CreateTrackOptions} */ (params);
 
@@ -360,6 +371,8 @@ class OutgoingStream extends Emitter
 				source.rtx.ssrc	= 0;
 				source.fec.ssrc = 0;
 			}
+			if (params.rid)
+				source.rid = params.rid;
 		}
 		
 		//Check we are not duplicating tracks

--- a/lib/OutgoingStream.js
+++ b/lib/OutgoingStream.js
@@ -365,8 +365,8 @@ class OutgoingStream extends Emitter
 			//If video
 			if (media=="video")
 			{
-				source.rtx.ssrc	= params.ssrcs ? params.ssrcs.rtx : this.lfsr.seq(31);
-				source.fec.ssrc = params.ssrcs ? params.ssrcs.fec : this.lfsr.seq(31);
+				source.rtx.ssrc	= params?.ssrcs?.rtx ?? this.lfsr.seq(31);
+				source.fec.ssrc = params?.ssrcs?.fec ?? this.lfsr.seq(31);
 			} else {
 				source.rtx.ssrc	= 0;
 				source.fec.ssrc = 0;

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -74,6 +74,7 @@ const noop = function(){};
  * @typedef {Object} CreateStreamTrackOptions
  * @property {string} [id] Stream track id (default: "audio" for audio tracks, "video" for video tracks)
  * @property {string} [mediaId] Stream track media id (mid)
+ * @property {string} [rid] Stream track rid
  * @property {SSRCs} [ssrcs] Override the generated ssrcs for this track
  */
 
@@ -195,6 +196,55 @@ class Transport extends Emitter
 		) => {
 			this.emit("remoteicecandidate", new CandidateInfo("1", 1, "UDP", priority, ip, port, "host"), this);
 		};
+
+		this.onunsignaledincomingsourcegroup = (
+			/** @type Native.RTPIncomingSourceGroupShared*/ group
+		) => {
+			//Create shared pointer wrapper
+			const shared = SharedPointer(group);
+			//Get group mid
+			const mid = shared.mid;
+			const encodingId = shared.rid;
+
+			let track;
+
+			//Try to find the track in all the streams
+			for (const incomingStream of this.incomingStreams.values())
+			{
+				for (const incomingStreamTrack of incomingStream.getTracks())
+				{
+					if (incomingStreamTrack.getMediaId() == mid)
+					{
+						track = incomingStreamTrack
+						break;
+					}
+				}
+			}
+			//If not, try on standalone tracks
+			if (!track)
+			{
+				for (const incomingStreamTrack of this.incomingStreamTracks.values())
+				{
+					if (incomingStreamTrack.getMediaId() == mid)
+					{
+						track = incomingStreamTrack
+						break;
+					}
+				}
+			}
+			//If found
+			if (track)
+			{
+				//Add new source to track
+				track.addIncomingSource(encodingId,shared);
+				//When track is ended
+				track.on("stopped",()=>{
+					//Remove source group
+					this.transport.RemoveIncomingSourceGroup(shared);
+				});
+			}
+		};
+
 		//Craeate transport listener
 		this.listener = new Native.DTLSICETransportListenerShared(this);
 		//Set it
@@ -661,6 +711,8 @@ class Transport extends Emitter
 			{
 				//Crete new track
 				let track = new TrackInfo("audio", audio.id || ("audio" + (maxId++)));
+				//Set mid
+				track.setMediaId(audio.mediaId);
 				//Generte new ssrc
 				let ssrc = audio.ssrcs ? audio.ssrcs.media : this.lfsr.seq(31);
 				let rtx  = audio.ssrcs ? audio.ssrcs.rtx   : this.lfsr.seq(31);
@@ -679,6 +731,7 @@ class Transport extends Emitter
 				info.addTrack(track);
 			}
 		}
+
 		//If we have video
 		if (params && params.video)
 		{
@@ -690,6 +743,8 @@ class Transport extends Emitter
 			{
 				//Crete new track
 				let track = new TrackInfo("video", video.id || ("video" + (maxId++)));
+				//Set mid
+				track.setMediaId(video.mediaId);
 				//Generte new ssrc
 				let ssrc = video.ssrcs ? video.ssrcs.media : this.lfsr.seq(31);
 				let fec  = video.ssrcs ? video.ssrcs.fec   : this.lfsr.seq(31);
@@ -712,6 +767,9 @@ class Transport extends Emitter
 					track.addSSRC(fec);
 					track.addSourceGroup (new SourceGroupInfo("FEC-FR",[ssrc,fec]));
 				}
+
+				if (video.encodings)
+					track.addEncoding(SemanticSDP.TrackEncodingInfo.expand(video.encodings[0][0]));
 
 				//Add track to stream
 				info.addTrack(track);
@@ -784,6 +842,9 @@ class Transport extends Emitter
 			source.rtx.ssrc = 0;
 			source.fec.ssrc	= 0;
 		}
+
+		if (opts?.mid)
+			source.mid = mid;
 
 		//Add it to transport
 		if (!this.transport.AddOutgoingSourceGroup(source))

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "uuid": "^3.3.2"
   },
   "peerDependencies": {
-    "medooze-media-server-src": "^1.4.0"
+    "medooze-media-server-src": "^2.0.0"
   },
   "optionalDependencies": {
     "netlink": "^0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medooze-media-server",
-  "version": "1.149.1",
+  "version": "1.150.0",
   "description": "WebRTC Media Server by Medooze",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/medooze/media-server-node#readme",
   "dependencies": {
     "lfsr": "0.0.3",
-    "medooze-event-emitter": "^1.0.0",
+    "medooze-event-emitter": "^1.2.0",
     "nan": "^2.18.0",
     "semantic-sdp": "^3.28.0",
     "uuid": "^3.3.2"

--- a/src/DTLSICETransportListener.i
+++ b/src/DTLSICETransportListener.i
@@ -75,6 +75,24 @@ public:
 		});
 	}
 
+	virtual void onUnsignaledIncomingSourceGroup(const RTPIncomingSourceGroup::shared& group)
+	{
+		Log("-DTLSICETransportListener::onUnsignaledIncomingSourceGroup()\n");
+		//Run function on main node thread
+		MediaServer::Async([=,cloned=persistent](){
+			Log("-DTLSICETransportListener::onUnsignaledIncomingSourceGroup() async\n");
+			//We create shared pointer for connection pointer
+			auto shared = new std::shared_ptr<RTPIncomingSourceGroup>(group);
+			Nan::HandleScope scope;
+			int i = 0;
+			v8::Local<v8::Value> argv[1];
+			//Create local args
+			argv[i++] = SWIG_NewPointerObj(SWIG_as_voidptr(shared), SWIGTYPE_p_RTPIncomingSourceGroupShared,SWIG_POINTER_OWN);
+			//Call object method with arguments
+			MakeCallback(cloned, "onunsignaledincomingsourcegroup",i,argv);
+		});
+	}
+
 private:
 	std::shared_ptr<Persistent<v8::Object>> persistent;
 };

--- a/src/RTPOutgoingSourceGroup.i
+++ b/src/RTPOutgoingSourceGroup.i
@@ -9,6 +9,8 @@ struct RTPOutgoingSourceGroup
 	RTPOutgoingSourceGroup(const std::string &streamId,MediaFrameType type, TimeService& TimeService);
 	
 	MediaFrameType  type;
+	std::string rid;
+	std::string mid;
 	const RTPOutgoingSource media;
 	const RTPOutgoingSource fec;
 	const RTPOutgoingSource rtx;

--- a/src/media-server_wrap.cxx
+++ b/src/media-server_wrap.cxx
@@ -2611,6 +2611,24 @@ public:
 		});
 	}
 
+	virtual void onUnsignaledIncomingSourceGroup(const RTPIncomingSourceGroup::shared& group)
+	{
+		Log("-DTLSICETransportListener::onUnsignaledIncomingSourceGroup()\n");
+		//Run function on main node thread
+		MediaServer::Async([=,cloned=persistent](){
+			Log("-DTLSICETransportListener::onUnsignaledIncomingSourceGroup() async\n");
+			//We create shared pointer for connection pointer
+			auto shared = new std::shared_ptr<RTPIncomingSourceGroup>(group);
+			Nan::HandleScope scope;
+			int i = 0;
+			v8::Local<v8::Value> argv[1];
+			//Create local args
+			argv[i++] = SWIG_NewPointerObj(SWIG_as_voidptr(shared), SWIGTYPE_p_RTPIncomingSourceGroupShared,SWIG_POINTER_OWN);
+			//Call object method with arguments
+			MakeCallback(cloned, "onunsignaledincomingsourcegroup",i,argv);
+		});
+	}
+
 private:
 	std::shared_ptr<Persistent<v8::Object>> persistent;
 };
@@ -6707,6 +6725,128 @@ static SwigV8ReturnValue _wrap_RTPOutgoingSourceGroup_type_get(v8::Local<v8::Nam
   arg1 = reinterpret_cast< RTPOutgoingSourceGroup * >(argp1);
   result = (MediaFrameType) ((arg1)->type);
   jsresult = SWIG_From_int(static_cast< int >(result));
+  
+  
+  SWIGV8_RETURN_INFO(jsresult, info);
+  
+  goto fail;
+fail:
+  SWIGV8_RETURN_INFO(SWIGV8_UNDEFINED(), info);
+}
+
+
+static void _wrap_RTPOutgoingSourceGroup_rid_set(v8::Local<v8::Name> property, v8::Local<v8::Value> value, const SwigV8PropertyCallbackInfoVoid &info) {
+  SWIGV8_HANDLESCOPE();
+  
+  RTPOutgoingSourceGroup *arg1 = (RTPOutgoingSourceGroup *) 0 ;
+  std::string *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 = SWIG_OLDOBJ ;
+  
+  res1 = SWIG_ConvertPtr(info.Holder(), &argp1,SWIGTYPE_p_RTPOutgoingSourceGroup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "RTPOutgoingSourceGroup_rid_set" "', argument " "1"" of type '" "RTPOutgoingSourceGroup *""'"); 
+  }
+  arg1 = reinterpret_cast< RTPOutgoingSourceGroup * >(argp1);
+  {
+    std::string *ptr = (std::string *)0;
+    res2 = SWIG_AsPtr_std_string(value, &ptr);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "RTPOutgoingSourceGroup_rid_set" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "RTPOutgoingSourceGroup_rid_set" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    arg2 = ptr;
+  }
+  if (arg1) (arg1)->rid = *arg2;
+  
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  
+  goto fail;
+fail:
+  return;
+}
+
+
+static SwigV8ReturnValue _wrap_RTPOutgoingSourceGroup_rid_get(v8::Local<v8::Name> property, const SwigV8PropertyCallbackInfo &info) {
+  SWIGV8_HANDLESCOPE();
+  
+  SWIGV8_VALUE jsresult;
+  RTPOutgoingSourceGroup *arg1 = (RTPOutgoingSourceGroup *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  std::string *result = 0 ;
+  
+  res1 = SWIG_ConvertPtr(info.Holder(), &argp1,SWIGTYPE_p_RTPOutgoingSourceGroup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "RTPOutgoingSourceGroup_rid_get" "', argument " "1"" of type '" "RTPOutgoingSourceGroup *""'"); 
+  }
+  arg1 = reinterpret_cast< RTPOutgoingSourceGroup * >(argp1);
+  result = (std::string *) & ((arg1)->rid);
+  jsresult = SWIG_From_std_string(static_cast< std::string >(*result));
+  
+  
+  SWIGV8_RETURN_INFO(jsresult, info);
+  
+  goto fail;
+fail:
+  SWIGV8_RETURN_INFO(SWIGV8_UNDEFINED(), info);
+}
+
+
+static void _wrap_RTPOutgoingSourceGroup_mid_set(v8::Local<v8::Name> property, v8::Local<v8::Value> value, const SwigV8PropertyCallbackInfoVoid &info) {
+  SWIGV8_HANDLESCOPE();
+  
+  RTPOutgoingSourceGroup *arg1 = (RTPOutgoingSourceGroup *) 0 ;
+  std::string *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 = SWIG_OLDOBJ ;
+  
+  res1 = SWIG_ConvertPtr(info.Holder(), &argp1,SWIGTYPE_p_RTPOutgoingSourceGroup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "RTPOutgoingSourceGroup_mid_set" "', argument " "1"" of type '" "RTPOutgoingSourceGroup *""'"); 
+  }
+  arg1 = reinterpret_cast< RTPOutgoingSourceGroup * >(argp1);
+  {
+    std::string *ptr = (std::string *)0;
+    res2 = SWIG_AsPtr_std_string(value, &ptr);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "RTPOutgoingSourceGroup_mid_set" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "RTPOutgoingSourceGroup_mid_set" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    arg2 = ptr;
+  }
+  if (arg1) (arg1)->mid = *arg2;
+  
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  
+  goto fail;
+fail:
+  return;
+}
+
+
+static SwigV8ReturnValue _wrap_RTPOutgoingSourceGroup_mid_get(v8::Local<v8::Name> property, const SwigV8PropertyCallbackInfo &info) {
+  SWIGV8_HANDLESCOPE();
+  
+  SWIGV8_VALUE jsresult;
+  RTPOutgoingSourceGroup *arg1 = (RTPOutgoingSourceGroup *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  std::string *result = 0 ;
+  
+  res1 = SWIG_ConvertPtr(info.Holder(), &argp1,SWIGTYPE_p_RTPOutgoingSourceGroup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "RTPOutgoingSourceGroup_mid_get" "', argument " "1"" of type '" "RTPOutgoingSourceGroup *""'"); 
+  }
+  arg1 = reinterpret_cast< RTPOutgoingSourceGroup * >(argp1);
+  result = (std::string *) & ((arg1)->mid);
+  jsresult = SWIG_From_std_string(static_cast< std::string >(*result));
   
   
   SWIGV8_RETURN_INFO(jsresult, info);
@@ -19977,6 +20117,8 @@ SWIGV8_AddMemberVariable(_exports_RTPOutgoingSource_class, "reportedFractionLost
 SWIGV8_AddMemberVariable(_exports_RTPOutgoingSource_class, "reportedJitter", _wrap_RTPOutgoingSource_reportedJitter_get, _wrap_RTPOutgoingSource_reportedJitter_set);
 SWIGV8_AddMemberVariable(_exports_RTPOutgoingSource_class, "rtt", _wrap_RTPOutgoingSource_rtt_get, _wrap_RTPOutgoingSource_rtt_set);
 SWIGV8_AddMemberVariable(_exports_RTPOutgoingSourceGroup_class, "type", _wrap_RTPOutgoingSourceGroup_type_get, _wrap_RTPOutgoingSourceGroup_type_set);
+SWIGV8_AddMemberVariable(_exports_RTPOutgoingSourceGroup_class, "rid", _wrap_RTPOutgoingSourceGroup_rid_get, _wrap_RTPOutgoingSourceGroup_rid_set);
+SWIGV8_AddMemberVariable(_exports_RTPOutgoingSourceGroup_class, "mid", _wrap_RTPOutgoingSourceGroup_mid_get, _wrap_RTPOutgoingSourceGroup_mid_set);
 SWIGV8_AddMemberVariable(_exports_RTPOutgoingSourceGroup_class, "media", _wrap_RTPOutgoingSourceGroup_media_get, JS_veto_set_variable);
 SWIGV8_AddMemberVariable(_exports_RTPOutgoingSourceGroup_class, "fec", _wrap_RTPOutgoingSourceGroup_fec_get, JS_veto_set_variable);
 SWIGV8_AddMemberVariable(_exports_RTPOutgoingSourceGroup_class, "rtx", _wrap_RTPOutgoingSourceGroup_rtx_get, JS_veto_set_variable);


### PR DESCRIPTION
This PR adds support for detecting unsignaled sources that provides relevant `mid` and `rid` values.

The `mid` is used for selecting the track to associate the id, and the `rid` for the source id. RTX ssrc is associated by `rid` or `rrid` afterwards.
