### PR TITLE
update min semantic-sdp version

### DIFF
--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -53,6 +53,12 @@ const parseInt = /** @type {(x: number) => number} */ (global.parseInt);
  * @property {SemanticSDP.CandidateInfo[]} candidates
  */
 
+/**
+ * @typedef {Object} CreateOfferParameters
+ * @property {boolean} [unified] - Generate unified plan like media ids
+ */
+
+
 /** @returns {ParsedPeerInfo} */
 function parsePeerInfo(/** @type {PeerInfo | SemanticSDP.SDPInfo} */ info)
 {
@@ -310,16 +316,18 @@ class Endpoint extends Emitter
 	 * Helper that creates an offer from capabilities
 	 * It generates a random ICE username and password and gets endpoint fingerprint
 	 * @param {SemanticSDP.Capabilities} [capabilities] - Media capabilities as required by SDPInfo.create
+	 * @param {CreateOfferParameters} [params]
 	 * @returns {SDPInfo} - SDP offer
 	 */
-	createOffer(capabilities)
+	createOffer(capabilities, params)
 	{
 		//Create offer
 		return SDPInfo.create({
 			dtls		: new DTLSInfo(Setup.ACTPASS,"sha-256",this.fingerprint),
 			ice		: ICEInfo.generate(true),
 			candidates	: this.getLocalCandidates(),
-			capabilities	: capabilities
+			capabilities	: capabilities,
+			unified		: !!params?.unified
 		});
 	}
 	

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "uuid": "^3.3.2"
   },
   "peerDependencies": {
-    "medooze-media-server-src": "^1.4.0"
+    "medooze-media-server-src": "^2.0.0"
   },
   "optionalDependencies": {
     "netlink": "^0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medooze-media-server",
-  "version": "1.149.1",
+  "version": "1.150.0",
   "description": "WebRTC Media Server by Medooze",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lfsr": "0.0.3",
     "medooze-event-emitter": "^1.0.0",
     "nan": "^2.18.0",
-    "semantic-sdp": "^3.28.0",
+    "semantic-sdp": "^3.29.0",
     "uuid": "^3.3.2"
   },
   "peerDependencies": {

--- a/tests/endpoint.js
+++ b/tests/endpoint.js
@@ -107,6 +107,48 @@ tap.test("Endpoint::create",async function(suite){
 		test.end();
 	});
 
+	await suite.test("createOffer",async function(test){
+		//Create UDP server endpoint
+		const endpoint = MediaServer.createEndpoint("127.0.0.1");
+		//Create non unified sdp
+		const offer = endpoint.createOffer({
+			audio   : {
+				codecs	: [ "opus"],
+				rtx     : true,
+				rtcpfbs : [
+					{ "id": "nack" },
+				],
+				extensions: ["urn:ietf:params:rtp-hdrext:ssrc-audio-level"]
+			},
+		});
+		//Check mid
+		test.same(offer.getMedias()[0].getId(), "audio");
+		//Ok
+		test.end();
+	});
+
+	await suite.test("createOffer",async function(test){
+		//Create UDP server endpoint
+		const endpoint = MediaServer.createEndpoint("127.0.0.1");
+		//Create non unified sdp
+		const offer = endpoint.createOffer({
+			audio   : {
+				codecs	: [ "opus"],
+				rtx     : true,
+				rtcpfbs : [
+					{ "id": "nack" },
+				],
+				extensions: ["urn:ietf:params:rtp-hdrext:ssrc-audio-level"]
+			},
+		},{
+			unified: true
+		});
+		//Check mid
+		test.same(offer.getMedias()[0].getId(), "0");
+		//Ok
+		test.end();
+	});
+
 	suite.end();
 })
 ]).then(()=>MediaServer.terminate ());


### PR DESCRIPTION
This PR allows using the new `unified` option in semantic-sdp for using unified plan mids.

https://github.com/medooze/semantic-sdp-js/pull/41/