### PR TITLE
feat: allow specifying codec preferences on setTargetBitrate()

### DIFF
--- a/lib/IncomingStreamTrack.js
+++ b/lib/IncomingStreamTrack.js
@@ -25,6 +25,7 @@ const {
  * @property {number} [targetWidth] signaled target width on the VideoLayersAllocation header
  * @property {number} [targetHeight] signaled target height on the VideoLayersAllocation header
  * @property {number} [targetFps] signaled target fps on the VideoLayersAllocation header
+ * @property {string} codec Name of the codec last in use
  */
 
 /**
@@ -129,6 +130,7 @@ const {
  * @property {number} [targetWidth] signaled target width on the VideoLayersAllocation header
  * @property {number} [targetHeight] signaled target height on the VideoLayersAllocation header
  * @property {number} [targetFps] signaled target fps on the VideoLayersAllocation header
+ * @property {string} codec Name of the codec last in use
  */
 
 /**
@@ -166,11 +168,12 @@ function getEncodingStats(/** @type {Encoding} */ encoding)
 		numPacketsDelta	: mediaStats.numPacketsDelta + rtxStats.numPacketsDelta,
 		remb		: encoding.source.remoteBitrateEstimation,
 		// timestamps
-		timestamp: Date.now(),
+		timestamp	: Date.now(),
 		// provisional (set by updateStatsSimulcastIndex)
-		simulcastIdx: -1,
-		codec: encoding.source.codec,
+		simulcastIdx	: -1,
+		codec		: encoding.source.codec,
 	};
+	//Calculate packet lost ration from total num packets
 	encodingStats.lostPacketsRatio = encodingStats.numPackets? encodingStats.lostPackets / encodingStats.numPackets : 0;
 	//If we have dimenstions
 	if (mediaStats.width && mediaStats.height)
@@ -263,7 +266,8 @@ function getStatsFromIncomingSource(/** @type {Native.RTPIncomingSource} */ sour
 			totalBitrate	: layer.totalBitrate,
 			active		: layer.active, 
 			// provisional (set by updateStatsSimulcastIndex)
-			simulcastIdx: -1,
+			simulcastIdx	: -1,
+			codec		: "unknown"
 		}
 		//Add optional attributes
 		if (layer.targetBitrate>0)
@@ -301,6 +305,7 @@ function getStatsFromIncomingSource(/** @type {Native.RTPIncomingSource} */ sour
 				totalBitrate	: 0,
 				// provisional (set by updateStatsSimulcastIndex)
 				simulcastIdx	: -1,
+				codec		: "unknown"
 			};
 
 			//Add optional attributes
@@ -358,7 +363,7 @@ function sortByBitrateReverse(/** @type {EncodingStats|LayerStats|ActiveEncoding
 		: b.bitrate - a.bitrate;
 }
 
-function updateStatsSimulcastIndex(/** @type {TrackStats} */ stats)
+function updateStatsSimulcastIndexAndCodec(/** @type {TrackStats} */ stats)
 {
 	//Set simulcast index
 	let simulcastIdx = 0;
@@ -370,11 +375,17 @@ function updateStatsSimulcastIndex(/** @type {TrackStats} */ stats)
 		stat.simulcastIdx = stat.bitrate ? simulcastIdx++ : -1;
 		//For all layers
 		for (const layer of stat.media.layers)
+		{
 			//Set it also there
 			layer.simulcastIdx = stat.simulcastIdx;
+			layer.codec = stat.codec;
+		}
 		for (const layer of stat.media.individual || [])
+		{
 			//Set it also there
 			layer.simulcastIdx = stat.simulcastIdx;
+			layer.codec = stat.codec;
+		}
 	}
 }
 
@@ -409,6 +420,7 @@ function getActiveLayersFromStats(/** @type {TrackStats} */ stats)
 			numPackets	: stats[id].numPackets,
 			bitrate		: stats[id].bitrate,
 			totalBitrate	: stats[id].totalBitrate,
+			codec		: stats[id].codec,
 			layers		: []
 		};
 
@@ -452,6 +464,7 @@ function getActiveLayersFromStats(/** @type {TrackStats} */ stats)
 				targetFps	: layer.targetFps,
 				width		: layer.width,
 				height		: layer.height,
+				codec		: layer.codec,
 			};
 
 			//Append to encoding
@@ -481,6 +494,7 @@ function getActiveLayersFromStats(/** @type {TrackStats} */ stats)
 				targetFps	: encoding.targetFps,
 				width		: encoding.width,
 				height		: encoding.height,
+				codec		: encoding.codec,
 			});
 				
 		//Add to encoding list
@@ -650,7 +664,7 @@ class IncomingStreamTrack extends Emitter
 		}
 		
 		//Update silmulcast index for layers
-		updateStatsSimulcastIndex(this.stats);
+		updateStatsSimulcastIndexAndCodec(this.stats);
 
 		//Return a clone of cached stats;
 		return this.stats;
@@ -680,7 +694,7 @@ class IncomingStreamTrack extends Emitter
 		}
 		
 		//Update silmulcast index for layers
-		updateStatsSimulcastIndex(this.stats);
+		updateStatsSimulcastIndexAndCodec(this.stats);
 		
 		//Return stats
 		return this.stats;
@@ -981,7 +995,8 @@ class IncomingStreamTrack extends Emitter
 	}
 }
 
+IncomingStreamTrack.sortByBitrateReverse = sortByBitrateReverse;
 IncomingStreamTrack.getActiveLayersFromStats = getActiveLayersFromStats;
-IncomingStreamTrack.updateStatsSimulcastIndex = updateStatsSimulcastIndex;
+IncomingStreamTrack.updateStatsSimulcastIndexAndCodec = updateStatsSimulcastIndexAndCodec;
 
 module.exports = IncomingStreamTrack;

--- a/lib/IncomingStreamTrackSimulcastAdapter.js
+++ b/lib/IncomingStreamTrackSimulcastAdapter.js
@@ -212,7 +212,7 @@ class IncomingStreamTrackSimulcastAdapter extends Emitter
 		}
 
 		//Update silmulcast index for layers
-		IncomingStreamTrack.updateStatsSimulcastIndex(stats);
+		IncomingStreamTrack.updateStatsSimulcastIndexAndCodec(stats);
 
 		return stats;
 	}

--- a/lib/Transponder.js
+++ b/lib/Transponder.js
@@ -26,6 +26,7 @@ const SemanticSDP	= require("semantic-sdp");
  * @property {boolean} [strict] If there is not a layer with a bitrate lower thatn target, stop sending media [Default: false]
  * @property {boolean} [smooth] When going to a lower simulcast layer, keep the higher one visible [Default: true]
  * @property {boolean} [useDefaultEncoding] If there are no active layers, use the default encoding [Default: false]
+ * @property {string[]} [codecs] Codec preferences list in ascending order, layers with codec not present in codec list will be ignored
  */
 
 /**
@@ -307,7 +308,7 @@ class Transponder extends Emitter
 		};
 
 		//Depending on the traversal method
-		switch (options && options.traversal)
+		switch (options?.traversal)
 		{
 			case "spatial-temporal":
 				ordering = (a,b) => ((getSpatialLayerId(b)*LayerInfo.MaxLayerId+b.temporalLayerId) - (getSpatialLayerId(a)*LayerInfo.MaxLayerId+a.temporalLayerId));
@@ -327,16 +328,36 @@ class Transponder extends Emitter
 				if (this.maxWidth || this.maxHeight)
 					ordering = (a,b) => ((getSpatialLayerId(b)*LayerInfo.MaxLayerId+b.temporalLayerId) - (getSpatialLayerId(a)*LayerInfo.MaxLayerId+a.temporalLayerId));
 		}
+
+		//If we want to filter by codecs
+		const codecs = options?.codecs?.map(codec => codec.toLowerCase());
+		const codecSortByPreference = codecs 
+			? (/** @type {LayerStats} */a,/** @type {LayerStats} */b) => codecs.indexOf(a.codec) - codecs.indexOf(b.codec)
+			: undefined;
 		
 		//Get all active layers 
 		const info = this.track.getActiveLayers();
 		
 		//Filter layers by max TL and SL
-		const filtered = info.layers.filter(layer=>this.maxSpatialLayerId>=layer.spatialLayerId && this.maxTemporalLayerId>=layer.temporalLayerId);
+		const filtered = info.layers.filter(layer=> this.maxSpatialLayerId>=layer.spatialLayerId
+			&& this.maxTemporalLayerId>=layer.temporalLayerId
+			&& (!codecs || codecs.includes(layer?.codec.toLowerCase()))
+		);
 		
 		//Get layers and filter by max TL & SL
 		//We expect spatial/simulcast layers to ensure that a layer with higher bitrate has also higher width/heights in order to be able to properly select based on maxWidth/maxHeight
-		const layers = ordering ? filtered.sort(ordering) : filtered;
+		let layers = filtered;
+		
+		//If doing any sorting		
+		if (ordering && codecSortByPreference)
+			//Order codec preferences in ascending order and traversal
+			layers = layers.sort((a,b) => codecSortByPreference(a,b) || ordering(a,b));
+		else if (ordering)
+			//Order by traversal
+			layers = layers.sort(ordering);
+		else if (codecSortByPreference)
+			//Order codec preferences in ascending order and bitrate
+			layers = layers.sort((a,b) => codecSortByPreference(a,b) || IncomingStreamTrack.sortByBitrateReverse(a,b));
 		
 		//If there are no layers
 		if (!layers.length)


### PR DESCRIPTION
This PR allows to specify the codec preferences in order to choose the correct layer.  It will allow us to implement multi video codec simulcast and only use the layers that the client supports for layer switching.